### PR TITLE
Updates and Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
   
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - 7.0
   - hhvm
   
 notifications:

--- a/HD4.php
+++ b/HD4.php
@@ -47,7 +47,7 @@ class HD4 extends HDBase {
 	var $detectRequest = array();
 	var $error = '';
 	var $logger = null;
-	var $debug = true;
+	var $debug = false;
 	var $configFile = 'hdconfig.php';				// hdconfig.php is the v3x PHP config file name.
 	
 	var $config = array (

--- a/HDDevice.php
+++ b/HDDevice.php
@@ -233,28 +233,16 @@ class HDDevice extends HDBase {
 			}
 		}
 
-		// Benchmark - 20 points - Enough to tie break but not enough to overrule display or pixel ratio.
+		// Benchmark - 10 points - Enough to tie break but not enough to overrule display or pixel ratio.
 		if (! empty($props['benchmark'])) {
-			$total += 20;
+			$total += 10;
 			if (! empty($specs['benchmark_min']) && ! empty($specs['benchmark_max'])) {
 				if ((int) $props['benchmark'] >= (int) @$specs['benchmark_min'] && (int) $props['benchmark'] <= (int) @$specs['benchmark_max']) {
 					// Inside range
 					$result['benchmark'] = 10;
-					$result['benchmark_span'] = (int) 10;
 				} else {
-					// Calculate benchmark chunk spans .. as a tie breaker for close calls.
-					$result['benchmark'] = 0;
-					$steps = (int) ($specs['benchmark_max'] - $specs['benchmark_min']) / 10;
 					// Outside range
-					if ((int) $props['benchmark'] >= (int) @$specs['benchmark_max']) {
-						// Above range : Calculate how many steps above range
-						$tmp = (int) round(($props['benchmark'] - $specs['benchmark_max']) / $steps);
-						$result['benchmark_span'] = (int) 10 - (min(10, max(0, $tmp)));
-					} elseif ((int) $props['benchmark'] <= (int) @$specs['benchmark_min']) {
-						// Below range : Calculate how many steps above range
-						$tmp = (int) round(($specs['benchmark_min'] - $props['benchmark']) / $steps);
-						$result['benchmark_span'] = (int) 10 - (min(10, max(0, $tmp)));
-					}
+					$result['benchmark'] = 0;
 				}
 			}
 		}

--- a/examples.php
+++ b/examples.php
@@ -72,7 +72,7 @@ echo "</p>";
 // This is the most simple detection call - http headers are picked up automatically.
 // You're probably using a normal browser so expect this to reply with NOTFOUND
 echo "<h1>Simple Detection - Using your web browser standard headers (expect NotFound)</h1><p>";
-if ($hd->siteDetect()) {
+if ($hd->deviceDetect()) {
 	$tmp = $hd->getReply();
 	print_r($tmp);
 } else {
@@ -88,7 +88,7 @@ echo "</p>";
 echo "<h1>Simple Detection - Setting Headers for an N95</h1><p>";
 $hd->setDetectVar('user-agent','Mozilla/5.0 (SymbianOS/9.2; U; Series60/3.1 NokiaN95-3/20.2.011 Profile/MIDP-2.0 Configuration/CLDC-1.1 ) AppleWebKit/413');
 $hd->setDetectVar('x-wap-profile','http://nds1.nds.nokia.com/uaprof/NN95-1r100.xml');
-if ($hd->siteDetect()) {
+if ($hd->deviceDetect()) {
 	$tmp = $hd->getReply();
 	print_r($tmp);
 } else {
@@ -101,7 +101,7 @@ echo "</p>";
 // Note : We use the ipaddress to get the geoip location.
 echo "<h1>Simple Detection - Passing a different ip address</h1><p>";
 $hd->setDetectVar('ipaddress','64.34.165.180');
-if ($hd->siteDetect(array('options' => 'geoip,hd_specs'))) {
+if ($hd->deviceDetect(array('options' => 'geoip,hd_specs'))) {
 	$tmp = $hd->getReply();
 	print_r($tmp);
 } else {
@@ -114,7 +114,7 @@ echo "</p>";
 echo "<h1>Archive Information</h1><p>";
 $hd->setTimeout(500);
 $time_start = _getmicrotime();
-if ($hd->siteFetchArchive()) {
+if ($hd->deviceFetchArchive()) {
 	$data = $hd->getRawReply();
 	echo "Downloaded ".strlen($data)." bytes";
 } else {

--- a/tests/benchmark.php
+++ b/tests/benchmark.php
@@ -1,0 +1,125 @@
+<?php
+
+ini_set('display_errors', 1);
+ini_set('max_execution_time', 120);
+ini_set('memory_limit', "128M");
+error_reporting(E_ALL | E_STRICT);
+
+//$configFile = 'hdconfig.php';
+$configFile = "../hd4UltimateConfig.php";
+$dataFile = "benchmarkData.txt";
+
+// Ensure config file present.
+if (! file_exists($configFile))
+	die('Config file not found');
+
+// Ensure data file present
+if (! file_exists($dataFile))
+	die('Data file not found');
+
+include($configFile);
+if (@$hdconfig['username'] == "your_api_username")
+	die('Please configure your username, secret and site_id');
+
+require_once('../HD4.php');
+$hd = new HandsetDetection\HD4($configFile);
+
+class FileException extends Exception {};
+
+class Benchmark {
+
+	private $file;
+	private $time_start;
+	private $time;
+	private $headers;
+	var $count = 0;
+	private $verbose = false;
+
+	function __construct($filename) {
+		try {
+			$this->file = fopen($filename, "r");
+		} catch(FileException $e) {
+			echo "File error: ".$e->getMessage();
+			exit(1);
+		}
+
+		while (!feof($this->file)) {
+			$line_of_text = fgets($this->file);
+			$this->headers[] = explode("|", $line_of_text);
+		}
+	}
+
+	private function getmicrotime() {
+		list($usec, $sec) = explode(" ",microtime());
+		return ((float)$usec + (float)$sec);
+	}
+
+	function flyThrough($hd) {
+		$hd->setup();
+		$this->time_start = $this->getmicrotime();
+
+		foreach($this->headers as $key => $device) {
+			$hd->setDetectVar("User-Agent", $device[0]);
+			$hd->setDetectVar("x-wap-profile", $device[1]);
+			$result = $hd->deviceDetect();
+
+			if ($this->verbose) {
+				echo "<tr>";
+				echo "<td>$this->count</td>";
+				if ($result) {
+					$reply = $hd->getReply();
+					echo "<td>".@$reply['hd_specs']['general_vendor']."</td>";
+					echo "<td>".@$reply['hd_specs']['general_model']."</td>";
+					echo "<td>".@$reply['hd_specs']['general_platform']."</td>";
+					echo "<td>".@$reply['hd_specs']['general_platform_version']."</td>";
+					echo "<td>".@$reply['hd_specs']['general_browser']."</td>";
+					echo "<td>".@$reply['hd_specs']['general_browser_version']."</td>";
+					echo "<td>".print_r($device, true)."</td>";
+				} else {
+					echo "<td colspan='7'> Got nothing for : ".print_r($device, true)."</td>";
+				}
+				echo "</tr>";
+			}
+			$this->count++;
+			if ($this->count > 1) break;
+		}
+		$this->time = $this->getmicrotime() - $this->time_start;
+	}
+
+	function header() {
+		if ($this->verbose) {
+			$str = <<<TAG
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Test headers</title>
+	<style type="text/css">
+		body { background-color: lemonchiffon; }
+		table { background-color: #fff; }
+		tr:nth-child(even) {background: #f1f1f1; }
+		tr:nth-child(odd) {background: #FFF; }
+	</style>
+</head>
+<body>
+TAG;
+			echo $str;
+			echo "<table style='font-size:12px'><tr><th>Count</th><th>Vendor</th><th>Model</th><th>Platform</th><th>Platform Version</th><th>Browser</th><th>Browser Version</th><th>HTTP Headers</th></tr>";
+		}
+	}
+
+	function footer() {
+		if ($this->verbose) {
+			echo "</body></table>";
+			echo "<div style=\"color:#f00;\">Test Complete</div>";
+		}
+		$dps = $this->count / round($this->time,4);
+		$dps = round($dps, 0);
+		echo "<h3>Elapsed time: ".round($this->time,4)."s, Total detections: $this->count, Detections per second: $dps</h3>\n\n";
+	}
+
+}
+$test = new Benchmark($dataFile);
+$test->header();
+$test->flyThrough($hd);
+$test->footer();
+?>

--- a/tests/benchmarkData.txt
+++ b/tests/benchmarkData.txt
@@ -1,0 +1,1064 @@
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0; GTB7.1; SLCC1; .NET CLR 2.0.50727; Media Center PC 5.0; InfoPath.2; .NET CLR 3.5.30729; .NET4.0C; .NET CLR 3.0.30729; AskTbFWV5/5.12.2.16749; 978803803)|
+WordPress/3.1; http://www.rimplaybook.biz|
+Opera/9.80 (X11; Linux zvav; U; en) Presto/2.8.119 Version/10.54|
+Opera/9.80 (X11; Linux zvav; U; es) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Windows; U; Windows NT 5.1; fr; rv:1.9.2.22) Gecko/20110902 Firefox/3.6.22 ( .NET CLR 3.5.30729) Swapper 1.0.4|
+Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; Trident/4.0; Swapper 1.0.5; Orange 7.4; Orange 8.0; SIMBAR={77B58263-85B3-4334-AB81-ECEEB41FE0EA}; NaviWoo2.0; InfoPath.2; .NET CLR 1.1.4322; Swapper 1.0.5; .NET CLR 2.0.50727; OfficeLiveConnector.1.3; OfficeLivePatch.0.0; .NET CLR 3.0.04506.30)|
+Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; BOLT/2.702) AppleWebKit/534.6 (KHTML, like Gecko) Version/5.0 Safari/534.6.3|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0; GTB6.6; Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1) ; SLCC1; .NET CLR 2.0.50727; InfoPath.2; .NET CLR 3.5.30729; .NET CLR 3.0.30729; 998603905703; Build/13.00319; 66660811703; 669607972803; 88980603; 668604633903; 9689028603; 66760656903; 896707603; 89670703903; 87890045703; 976905703; 988707903; 699902803803; 79680703; 999603803; 799801903; 97780703; 9789006903; 889800703; 877903667903; 787904628603; 97790972903; 7978010803; 666606|
+WordPress/MU; http://hetblackberrynieuws.wordpress.com|
+Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0; WOW64; FunWebProducts; SLCC1; .NET CLR 2.0.50727; Media Center PC 5.0; .NET CLR 3.5.30729; .NET CLR 3.0.30618; FunWebProducts; 797803803; layout/4.02124)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0; Swapper 1.0.4; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; MDDR; Swapper 1.0.4; .NET4.0C)|
+Opera/9.80 (X11; Linux i686; U; vi) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; BOLT/2.701) AppleWebKit/534.6 (KHTML, like Gecko) Version/5.0 Safari/534.6.3|
+Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1) ; .NET CLR 1.0.3705; .NET CLR 1.1.4322; Media Center PC 4.0; 979803803; Library2.02045)|
+Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; BOLT/2.700) AppleWebKit/534.6 (KHTML, like Gecko) Version/5.0 Safari/534.6.3|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0; SIMBAR={F5F6C5D0-6CF5-11DC-A19D-0013A950183F}; GTB7.1; SLCC1; .NET CLR 2.0.50727; Media Center PC 5.0; MSN Optimized;DE; Swapper 1.0.5; OfficeLiveConnector.1.3; OfficeLivePatch.0.0; .NET CLR 3.5.30729; .NET CLR 3.0.30729; MSN Optimized;DE)|
+Opera/9.80 (X11; Linux i686; U; en) Presto/2.8.119 Version/10.54|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; VB_hottieregion; GTB7.1; Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1) ; InfoPath.1; WinNT-PAI 28.07.2009; .NET CLR 2.0.50727; 979803803; Library2.02319)|
+Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.0; Trident/5.0; SLCC1; .NET CLR 2.0.50727; Media Center PC 5.1; InfoPath.2; .NET CLR 3.5.30729; .NET4.0C; .NET CLR 3.0.30729; 9768033603; control/5.00195; 886802803; 9877074903; 98770803; 666600503703; 699903603; 668609703; 97880603; 988703403803; 79680603; 79680703; 66960055603; 79680108603; 887803803; 97680443903; 87890377603; 8789026903; 6969014803; 87890703; 78690791703; 99760603; 9769030803; 78790603; 877907703; 88780603; 798805991903; 887804458603)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0; FunWebProducts; GTB7.1; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; InfoPath.2; SRS_IT_E879027EBD765C5230AD90; .NET4.0C; BRI/1; 7978090803; ver:2.00241; 97990603; 979807259803; 997601703; 7899084603; 8898077803; 96690903; 88780803; 7899002603; 9986016703; 977901194903; 798809079703; 786901803; 998608903; 88980903; 979904703; 9788072703; 886806303703; 669605760603; 97980594903; 7889065803; 797803803; 6|
+Cydia/0.9 CFNetwork/485.13.9 Darwin/11.0.0|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; Sky Broadband; GTB7.1; SeekmoToolbar 4.8.4; Sky Broadband; Sky Broadband; AskTbBLPV5/5.9.1.14019)|
+Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; BOLT/2.690) AppleWebKit/534.6 (KHTML, like Gecko) Version/5.0 Safari/534.6.3|
+Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; BOLT/2.680) AppleWebKit/534.6 (KHTML, like Gecko) Version/5.0 Safari/534.6.3|
+AppEngine-Google; (+http://code.google.com/appengine; appid: domotoast-proxy)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; GTB7.1; InfoPath.3; AskTbFWV5/5.12.2.16749)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; FunWebProducts; GTB7.1; InfoPath.2; BRI/1; BRI/2)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; GTB7.1; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; MAPB; .NET4.0C; InfoPath.2)|
+Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729); DMBrowser: f0215e2b-eb35-4cd1-8662-aa12ec8758ef|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0; FunWebProducts; GTB6.6; SLCC1; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30618; AskTbIJBME/5.11.3.15590; 78690773903; Library1.00164)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0; SIMBAR={A4105742-BEFE-40FF-BC15-29D6915F8300}; SLCC1; .NET CLR 2.0.50727; .NET CLR 1.1.4322; .NET CLR 3.5.30729; .NET CLR 3.0.30618; .NET4.0C)|
+Mozilla/4.0 (compatible; MSIE 7.0; AOL 9.5; AOLBuild 4337.5401; Windows NT 6.1; WOW64; Trident/4.0; PicMorphSearchToolbar 1.2; FunWebProducts; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; CPDTDF; .NET4.0C; BRI/1; BRI/2; AskTbMP3R7/5.12.2.16749)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; GTB7.1; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; ShopperReports 3.0.489.0; SRS_IT_E879027FB176555632A995; yie8)|
+Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729); DMBrowser: af5176c1-b768-4348-9c57-38a598bc0ad7|
+Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0; GTB7.1; SLCC1; .NET CLR 2.0.50727; Media Center PC 5.0; .NET CLR 3.0.30618; InfoPath.2; OfficeLiveConnector.1.3; OfficeLivePatch.0.0; .NET CLR 3.5.30729)|
+Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0; GTB7.1; SLCC1; .NET CLR 2.0.50727; Media Center PC 5.0; .NET CLR 3.0.30618; InfoPath.2; OfficeLiveConnector.1.3; OfficeLivePatch.0.0; .NET CLR 3.5.30729)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0; FunWebProducts; GTB7.1; SLCC1; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30618; InfoPath.2; AskTbFWV5/5.12.2.16749; .NET4.0C)|
+Mozilla/4.0 (compatible; MSIE 7.0; AOL 9.1; AOLBuild 4334.5012; Windows NT 5.1; GTB7.0; .NET CLR 1.1.4322; Windows-Media-Player/10.00.00.3990)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0; GTB7.1; SLCC1; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30618; .NET4.0C; AskTbBT4/5.12.2.16749)|
+Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET4.0C; .NET4.0E; .NET CLR 3.5.30729; .NET CLR 3.0.30729); DMBrowser: 53aa9341-6d81-494a-a2b2-5daaaaa7661a|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; BTRS7391; GTB7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; eSobiSubscriber 2.0.4.16; MAAR; .NET4.0C)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; SIMBAR={D20B426C-84DF-11E0-80E5-1C7508C85D85}; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; MAAR; .NET4.0C; AskTbGLSV5/5.9.1.14019)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; GTB7.1; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; OfficeLiveConnector.1.4; OfficeLivePatch.1.3; .NET4.0C; InfoPath.3; BRI/1; BRI/2)|
+Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; Trident/4.0; SearchToolbar 1.1; InfoPath.1; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; yie8; XF_mmhpset)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0; GTB7.1; SLCC1; .NET CLR 2.0.50727; Media Center PC 5.0; .NET CLR 3.5.21022; .NET CLR 3.5.30729; .NET CLR 3.0.30729; .NET4.0C; AskTbPSI/5.12.2.16749; BO1IE8_v1;ENUS)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0; chromeframe/13.0.782.112; SLCC1; .NET CLR 2.0.50727; Media Center PC 5.0; .NET CLR 3.5.30729; .NET CLR 3.0.30618; .NET4.0C)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; GTB6; FunWebProducts; BTRS26539; InfoPath.1; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; msn OptimizedIE8;ENUS; AskTB5.6)|
+Mozilla/4.0 (compatible; MSIE 8.0; AOL 9.0; AOLBuild 4184.5450; Windows NT 5.1; Trident/4.0; GTB7.1; .NET CLR 1.0.3705; .NET CLR 1.1.4322; Media Center PC 4.0; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; NET_mmhpset)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; GTB6; .NET CLR 1.0.3705; .NET CLR 1.1.4322; Media Center PC 4.0; InfoPath.2; AskTbLMW2/5.12.2.16749)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; SearchToolbar 1.2; .NET CLR 1.1.4322; IEMB3; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; Dealio Toolbar 3.4)|
+Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0; GTB6; Sky Broadband; SLCC1; .NET CLR 2.0.50727; Media Center PC 5.0; .NET CLR 1.1.4322; .NET CLR 3.5.30729)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; GTB7.1; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; OfficeLiveConnector.1.5; OfficeLivePatch.1.3; .NET4.0C; InfoPath.2; .NET CLR 1.1.4322)|
+Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/4.0; SearchToolbar 1.2; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; HPNTDF; .NET4.0C; BRI/1; InfoPath.2; BRI/2)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0; SearchToolbar 1.2; BTRS6253; SLCC1; .NET CLR 2.0.50727; Media Center PC 5.0; .NET CLR 3.5.30729; .NET4.0C; .NET CLR 3.0.30729; yie8)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; chromeframe/13.0.782.112; yie8)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; (R1 1.6); .NET CLR 1.0.3705; .NET CLR 1.1.4322; Media Center PC 4.0; AskTbSTC3-SRS/5.12.2.16752; yie8)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; GTB7.1; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; eSobiSubscriber 2.0.4.16; .NET4.0C; InfoPath.2; AskTbMMG/5.12.2.16749)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; GTB7.0; .NET CLR 1.0.3705; .NET CLR 1.1.4322; Media Center PC 4.0; Media Center PC 3.0; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; AskTbFTB/5.11.3.15590)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0; GTB7.1; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; VER#4A#80836748566745484987484957; .NET4.0C)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; GTB7.1; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; VER#5B#80836750696745484948484849; InfoPath.3)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0; SLCC1; .NET CLR 2.0.50727; Media Center PC 5.0; .NET CLR 1.1.4322; InfoPath.2; .NET CLR 3.5.30729; .NET CLR 3.0.30618; .NET4.0C; BRI/1; BRI/2; AskTbGAM4/5.12.2.16749)|
+Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; GTB6; .NET CLR 1.1.4322; InfoPath.1; .NET CLR 2.0.50727; OfficeLiveConnector.1.3; OfficeLivePatch.0.0; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; AskTbFWV5/5.12.2.16749)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; FunWebProducts; .NET CLR 1.1.4322; .NET CLR 2.0.50727; FunWebProducts; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; yie8)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; FBSMTWB; .NET CLR 1.1.4322; InfoPath.1; SRS_IT_E8790776B776545030A995; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET CLR 2.0.50727; .NET4.0C; InfoPath.2)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; SearchToolbar 1.2; GTB7.0; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; AskTbWCL2/5.11.3.15590; .NET4.0C; .NET4.0E; ety8x_cfg)|
+Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729); DMBrowser: 2bfb6d5b-9f0b-4d4b-bd00-d6589a123acd|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0; BTRS5591; FunWebProducts; GTB7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; OfficeLiveConnector.1.3; OfficeLivePatch.0.0; AskTbNRO/5.12.2.16749; 969906853703; Library3.00152)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; WOW64; Trident/4.0; GTB7.1; SLCC1; .NET CLR 2.0.50727; Media Center PC 5.0; .NET CLR 3.5.21022; .NET CLR 3.5.30729; InfoPath.2; .NET CLR 3.0.30729; .NET4.0C; BRI/1; BRI/2; NET_mmhpset)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; GTB7.1; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.04506.30; .NET CLR 3.0.04506.648; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; OfficeLiveConnector.1.3; OfficeLivePatch.0.0; msn OptimizedIE8;ENUS; AskTB5.6)|
+Mozilla/4.0 (compatible; MSIE 8.0; AOL 9.6; AOLBuild 4340.5003; Windows NT 5.1; Trident/4.0; GTB6.6; .NET CLR 2.0.50727)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0; GTB7.0; SLCC1; .NET CLR 2.0.50727; Media Center PC 5.0; .NET CLR 1.1.4322; .NET CLR 3.5.21022; .NET CLR 3.5.30729; .NET CLR 3.0.30729; .NET4.0C; yie8)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; GTB7.1; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; HPNTDF; .NET4.0C; BRI/1; AskTbOVO/5.12.2.16749)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0; SLCC1; .NET CLR 2.0.50727; Media Center PC 5.0; .NET CLR 1.1.4322; .NET CLR 3.5.30729; .NET CLR 3.0.30729; IEMB3; .NET4.0C; BRI/1; yie8)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; FCTB100293; .NET CLR 1.1.4322; .NET4.0C; yie8)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET CLR 1.1.4322; .NET4.0C; BRI/1; AskTbAD2/5.12.2.16749; MALC)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; FunWebProducts; GTB7.1; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; HPDTDF; BRI/1; .NET4.0C; FunWebProducts; AskTbPPC/5.12.2.16749)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; EasyBits GO v1.0; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; BO2IE8_v1;ENUS)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; GTB7.1; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.04506.648; .NET CLR 3.5.21022; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; NET_mmhpset)|
+Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0; GTB7.1; SLCC1; .NET CLR 2.0.50727; Media Center PC 5.0; .NET CLR 1.1.4322; .NET CLR 3.5.30729; .NET CLR 3.0.30618; AskTbFWV5/5.9.1.14019)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; InfoPath.2; BRI/1; AskTbARS/5.12.1.16460)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; FunWebProducts; .NET CLR 1.0.3705; .NET CLR 1.1.4322; Media Center PC 4.0; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; WinNT-PAI 30.08.2009; MySpace;; yie8)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR 1.1.4322; BRI/1; BRI/2; BOIE8;ENUSMSCOM)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0; GTB7.1; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; MDDS; AskTbBCPA/5.12.2.16749)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0; FunWebProducts; GTB7.1; SLCC1; .NET CLR 2.0.50727; Media Center PC 5.0; .NET CLR 3.5.30729; .NET CLR 3.0.30729; .NET4.0C; AskTbAD2/5.9.1.14019)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; FunWebProducts; (R1 1.5); EasyBits GO v1.0; .NET CLR 1.1.4322)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; GTB7.1; .NET CLR 1.0.3705; .NET CLR 1.1.4322; Media Center PC 4.0; SDR6; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; GTB6; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; 878906803)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0; FunWebProducts; GTB7.1; SLCC1; .NET CLR 2.0.50727; .NAP 1.0; .NET CLR 3.5.30729; .NET CLR 3.0.30729; .NET4.0C)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; GTB7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; eSobiSubscriber 2.0.4.16; .NET CLR 1.1.4322; OfficeLiveConnector.1.5; OfficeLivePatch.1.3)|
+Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0; SearchToolbar 1.2; GTB7.1; SLCC1; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30618; SRS_IT_E8790571BD765C5436AE93)|
+Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0; SLCC1; .NET CLR 2.0.50727; Media Center PC 5.0; PeoplePal 6.6; .NET CLR 3.5.30729; .NET CLR 3.0.30618; BRI/1) w:PACBHO60|
+Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; Trident/4.0; CIBA; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; InfoPath.2; SE 2.X MetaSr 1.0)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; Comcast Install 1.0; GTB7.1; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.04506.30; .NET CLR 3.0.04506.648; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; AskTbORJ/5.12.3.17451)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; PBSTB 1.2; GTB7.1; Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1) ; .NET CLR 1.0.3705; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; IE0006_ver1;EN_US)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; GTB7.1; WinNT-PAI 15.08.2009; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; msn OptimizedIE8;ENUS)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; WOW64; Trident/4.0; FunWebProducts; SLCC1; .NET CLR 2.0.50727; Media Center PC 5.0; MDDC; .NET CLR 3.5.30729; .NET CLR 3.0.30729; OfficeLiveConnector.1.5; OfficeLivePatch.1.3; .NET4.0C; AskTbUT2V5/5.12.2.16749)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0; GTB7.1; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; MDDS; .NET4.0C; AskTbAD3/5.12.2.16749; BRI/1)|
+Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/5.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; InfoPath.3; Windows Live Messenger 15.4.3538.0513)|
+Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; Trident/5.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; BRI/2; AskTB5.5)|
+Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; GTB7.1; InfoPath.1; .NET CLR 2.0.50727; .NET CLR 3.0.04506.648; .NET CLR 3.5.21022; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; AskTbARS/5.11.4.15711; .NET CLR 1.1.4322)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0; EasyBits GO v1.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; MDDC; ShopperReports 3.0.497.0; SRS_IT_E8790570B4765D5436A997; .NET4.0C; AskTbFWV5/5.12.2.16749; InfoPath.3)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; SearchToolbar 1.2; Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1) ; AskTbWCL2/5.12.2.16749; .NAP 1.1)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0; GTB7.1; EasyBits GO v1.0; SLCC1; .NET CLR 2.0.50727; MDDC; .NET CLR 3.5.30729; .NET CLR 3.0.30729)|
+Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; Trident/4.0; GTB7.0; Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1) ; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.04506.30; .NET CLR 3.0.04506.648; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; OfficeLiveConnector.1.3; OfficeLivePatch.0.0; yie8; AskTB5.6)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; CMDTDF; AskTbORJ/5.12.3.17451)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; GTB7.1; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; VER#5B#80836750696745484948484849)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; FunWebProducts; GTB7.1; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; AskTbFWV5/5.12.2.16749; AskTB)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0; SLCC1; .NET CLR 2.0.50727; Media Center PC 5.0; PeoplePal 7.0; .NET CLR 1.1.4322; .NET CLR 3.5.30729; .NET CLR 3.0.30618; InfoPath.1; .NET4.0C)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; HPDTDF; InfoPath.2; .NET CLR 1.1.4322; .NET4.0C; 887806664703; compat/4.1.00302)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; SU 3.28; GTB7.1; .NET CLR 2.0.50727; FunWebProducts; AskTbFWV5/5.12.2.16749; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; yie8)|
+Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; .NET CLR 1.0.3705; .NET CLR 1.1.4322; Media Center PC 4.0; MS-RTC LM 8; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET4.0C)|
+Mozilla/4.0 (compatible; MSIE 8.0; AOL 9.1; AOLBuild 4334.5012; Windows NT 5.1; Trident/4.0; FunWebProducts; GTB7.0; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.04506.30; MDDC; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET4.0C)|
+Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; Trident/5.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; VER#Z9#80837689486745485080484950; .NET4.0C)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0; SLCC1; .NET CLR 2.0.50727; Media Center PC 5.0; Tablet PC 2.0; .NET CLR 3.5.30729; OfficeLiveConnector.1.5; OfficeLivePatch.1.3; .NET4.0C; .NET CLR 3.0.30729; BRI/1; BRI/2)|
+Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0; Trident/4.0; FunWebProducts; GTB6.6; SLCC1; .NET CLR 2.0.50727; InfoPath.2; .NET CLR 1.1.4322; .NET CLR 3.5.30729; .NET CLR 3.0.30729; .NET4.0C; BRI/1; FDM)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; GTB7.0; .NET CLR 2.0.50727; InfoPath.2; InfoPath.1)|
+Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/4.0; SearchToolbar 1.2; GTB6.4; FunWebProducts; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; eSobiSubscriber 2.0.4.16; .NET4.0C; FunWebProducts; AskTbFWV5/5.12.2.16749)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; GTB7.1; .NET CLR 1.0.3705; .NET CLR 1.1.4322; Media Center PC 4.0; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; OfficeLiveConnector.1.3; OfficeLivePatch.0.0; MS-RTC LM 8; Zune 4.7; InfoPath.3; BRI/2; .NET4.0C)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR 1.0.3705; Media Center PC 4.0; .NET CLR 1.1.4322; InfoPath.1; BOIE8;ENUSMSCOM)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; GTB7.1; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; FDM; .NET4.0E)|
+Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0; chromeframe/13.0.782.112; SLCC1; .NET CLR 2.0.50727; .NET CLR 1.1.4322; InfoPath.2; MS-RTC LM 8; .NET CLR 3.0.30729)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; GTB7.0; .NET CLR 2.0.50727; .NET CLR 1.1.4322; AskTbORJ/5.12.3.17451; yie8)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR 1.0.3705; .NET CLR 1.1.4322; Media Center PC 3.1; AskTbORJ/5.12.3.17451; yie8)|
+Mozilla/4.0 (compatible; MSIE 8.0; AOL 9.5; AOLBuild 4337.185; Windows NT 5.1; Trident/4.0; GTB7.1; .NET CLR 1.0.3705; .NET CLR 1.1.4322; .NET CLR 2.0.50727; Media Center PC 4.0; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; AskTB5.6; BO1IE8_v1;ENUS)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; GTB7.1; .NET CLR 3.0.04506.30; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; InfoPath.1; yie8)|
+Mozilla/4.0 (compatible; MSIE 8.0; AOL 9.6; AOLBuild 4340.5004; Windows NT 5.1; Trident/4.0; FBSMTWB; GTB7.1; .NET CLR 1.0.3705; .NET CLR 1.1.4322; Media Center PC 4.0; .NET CLR 2.0.50727; InfoPath.1; SpamBlockerUtility 4.8.4; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; WinTSU 08.10.2009; yie8)|
+Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; FunWebProducts; .NET CLR 2.0.50727; .NET CLR 3.0.04506.648; .NET CLR 3.5.21022; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET4.0C; FunWebProducts)|
+Mozilla/5.0 (Linux; U; Android 2.2.1; fr-fr; GT-I9003 Build/FROYO) AppleWebKit/525.10+ (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2 (AdMob-ANDROID-20091123)|
+Mozilla/5.0 (Linux; U; Android 2.1-update1; ar-eg; MB525 Build/JRDNEM_U3_2.59.0) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17|http://uaprof.motorola.com/phoneconfig/MotoMB525/profile/MotoMB525.rdf
+Nokia6085/2.0 (06.00) Profile/MIDP-2.0 Configuration/CLDC-1.1 nokia6085/UC Browser7.9.0.102/69/352 UNTRUSTED/1.0|http://nds1.nds.nokia.com/uaprof/N6085r100.xml
+MOT-ROKR E2/R564_G_12.01.46P K1nDinuX Mozilla/4.0 (compatible; MSIE 6.0; Linux; Motorola ROKR E2; 781) Profile/MIDP-2.0 Configuration/CLDC-1.1 Opera 8.50 [es-LA]|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[7658912216] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[2187703392] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Dalvik/1.4.0 (Linux; U; Android 2.3.3; SAMSUNG-SGH-I997 Build/GINGERBREAD)|
+Dalvik/1.4.0 (Linux; U; Android 2.3.1; TM-7022 Build/GINGERBREAD)|http://wap.sonyericsson.com/UAprof/LT15iR301.xml
+NokiaX2-01/5.0 (07.10) Profile/MIDP-2.1 Configuration/CLDC-1.1 nokiax2-01/UC Browser7.4.0.65/69/352 UNTRUSTED/1.0|http://nds1.nds.nokia.com/uaprof/NokiaX2-01r100.xml
+Blackberry 9300/6.0.0.668 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/168|http://www.blackberry.net/go/mobile/profiles/uaprof/9300_umts/5.0.0.rdf
+Mozilla/5.0 (Linux; U; Android 2.2.1; fr-fr; GT-S5570-ORANGE/S5570BVKE2 Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://gsm.lge.com/html/gsm/P990-M3-D2.xml
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.12168/26.984; U; en) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Symbian/3; Series60/5.2 NokiaE7-00/020.031; Profile/MIDP-2.1 Configuration/CLDC-1.1 ) AppleWebKit/533.4 (KHTML, like Gecko) NokiaBrowser/7.3.1.12 Mobile Safari/533.4 3gpp-gba|http://nds1.nds.nokia.com/uaprof/NE7-00r100.xml
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0 like Mac OS X; fr_FR) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/5.0;FBSS/2; FBCR/BouyguesTelecom;FBID/phone;FBLC/fr_FR;FBSF/2.0]|
+Mozilla/5.0 (Linux; U; Android 2.2.1; fr-fr; LG-P500 Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://gsm.lge.com/html/gsm/P990-M3-D2.xml
+Opera/9.80 (Android 2.3.4; Linux; Opera Mobi/ADR-1110071847; U; pt-BR) Presto/2.9.201 Version/11.50|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+LG-GW300/V100 Obigo/WAP2.0 Profile/MIDP-2.0 Configuration/CLDCgsm.lge.com/html/gsm/LG-GW300.xml|http://gsm.lge.com/html/gsm/LG-GW300.xml
+Dalvik/1.1.0 (Linux; U; Android v1.02_14.13-M-2011.01.10; RK2818 Build/ECLAIR)|
+Mozilla/5.0 (Linux; U; Android 2.1-update1; fr-fr; E130 Build/ERE27) AppleWebKit/525.10+ (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2 (AdMob-ANDROID-20091123)|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[2703661933] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+LG-LG511C/1.0[TFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX] Mozilla/5.0(compatible; Teleca Q7; BMP 1.0.1; U; en) 240X400 LGE LG-LG511C Profile/MIDP-2.1 Configuration/CLDC-1.1|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; tr_TR) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.3;FBSS/2; FBCR/VODAFONETR;FBID/phone;FBLC/tr_TR;FBSF/2.0]|
+Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 7.6) Vodafone/1.0/HTC_Kaiser/1.56.162.5|http://www.htcmms.com.tw/gen/Kaiser-1.0.xml
+Dalvik/1.1.0 (Linux; U; Android 2.1-update1; E400 Build/ECLAIR)|http://wap1.huawei.com/uaprof/HuaweiU8230v100WCDMAEclair.xml
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_1 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.1;FBSS/2; FBCR/Carrier;FBID/phone;FBLC/en_US;FBSF/2.0]|
+NokiaC1-01/2.0 (05.45) Profile/MIDP-2.1 Configuration/CLDC-1.1 Opera/9.60 (J2ME/MIDP;Opera Mini/5.2.13337.MTN.REMod.by.Andrewxy/503; U; en)Presto/2.2.0 UNTRUSTED/1.0|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_1 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone2,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.1;FBSS/1; FBCR/AT&T;FBID/phone;FBLC/en_US;FBSF/1.0]|
+Mozilla/5.0 (Linux; U; Android 2.3.3; en-us; SonyEricssonST15i Build/4.0.A.2.377) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[9032407354] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S8530/S8530XEJK6; U; Bada/1.2; fr-fr) AppleWebKit/533.1 (KHTML, like Gecko) Dolfin/2.2 Mobile WVGA SMM-MMS/1.2.0 NexPlayer/3.0 profile/MIDP-2.1 configuration/CLDC-1.1 OPN-B|http://wap.samsungmobile.com/uaprof/GT-S8530_3G.rdf
+MOT-K3/99.41.05R BER2.2 Mozilla/4.0 (compatible; MSIE 6.0; 12163189) Profile/MIDP-2.0 Configuration/CLDC-1.1  Opera 8.00 [ar]|http://motorola.handango.com/phoneconfig/K3/Profile/K3.rdf
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone2,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/5.0;FBSS/1; FBCR/OrangeUK;FBID/phone;FBLC/en_US;FBSF/1.0]|
+LG-GU295/V10i; Mozilla/5.0 (Profile/MIDP-2.0 Configuration/CLDC-1.1; Opera Mini/att/4.2.15957; U; es|http://gsm.lge.com/html/gsm/LG-GU295.xml
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_1 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone2,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.1;FBSS/1; FBCR/T-MobileUK;FBID/phone;FBLC/en_US;FBSF/1.0]|
+MQQBrowser/Mini2.2 (Nokia2690/10.10)|
+Mozilla/5.0 (Series40; NokiaX3-00/03.60; Profile/MIDP-2.1 Configuration/CLDC-1.1) Gecko/20100401 S40OviBrowser/1.4.0.34.8|http://nds1.nds.nokia.com/uaprof/NX3-00r100.xml
+Mozilla/5.0 (Symbian/3; Series60/5.2 Nokia500/010.031; Profile/MIDP-2.1 Configuration/CLDC-1.1 ) AppleWebKit/533.4 (KHTML, like Gecko) NokiaBrowser/7.3.1.37 Mobile Safari/533.4 3gpp-gba|
+Dalvik/1.4.0 (Linux; U; Android 2.3.4; T3 Build/GRJ22)|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Dalvik/1.4.0 (Linux; U; Android 2.3.4; MB855 Build/4.5.1A-1_SUN-128)|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Nokia6680/1.0 (5.04.07) SymbianOS/8.0 Series60/2.6 Profile/MIDP-2.0 Configuration/CLDC-1.1/UC Browser7.8.0.95/27/351|http://nds1.nds.nokia.com/uaprof/N6680r100.xml
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[8035218222] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+nokia6303classic/08.90; Opera/9.50 (J2ME/MIDP; Opera Mini/4.1.13961/546; de; U; ssr)|http://nds1.nds.nokia.com/uaprof/N6303classicr100.xml
+Dalvik/1.4.0 (Linux; U; Android 2.3.5; YP-G1 Build/GINGERBREAD)|
+Blackberry 8350i/4.6.1.278 Profile/MIDP-2.0 Configuration/CLDC-1.1 VendorID/317|
+Nokia7230/5.0 (09.83) Profile/MIDP-2.1 Configuration/CLDC-1.1 nokia7230/UC Browser7.9.0.102/70/352|http://nds1.nds.nokia.com/uaprof/N7230r100.xml
+Dalvik/1.4.0 (Linux; U; Android 2.3.7; HD2 Build/GRI40)|
+Dalvik/1.4.0 (Linux; U; Android 2.3.3; SBM006SH Build/S0018)|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[7154046673] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0;FBBV/4000.0;FBDV/iPhone2,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.3;FBSS/1; FBCR/AT|
+Dalvik/1.4.0 (Linux; U; Android 2.3.5; Xperia X8 Build/SEMC V3)|
+Dalvik/1.4.0 (Linux; U; Android 2.3.3; LG-P500 Build/AGA-ROM)|
+Mozilla/5.0 (SymbianOS/9.2; U; Series60/3.1 NOKIAN95 8GB/1.0; Profile/MIDP-2.0 Configuration/CLDC-1.1) AppleWebKit/413 (KHTML, like Gecko) Safari/413 Mozilla/5.0 (SymbianOS/9.2; U; Series60/3.1 NOKIAN95 8GB/1.0; Profile/MIDP-2.0 Configuration/CLDC-1.1) AppleWebKit/413 (KHTML, like Gecko) Safari/413 Mozilla/5.0 (SymbianOS/9.2; U; Series60/3.1 NOKIAN95 8GB/1.0; Profile/MIDP-2.0 Configuration/CLDC-1.1) AppleWebKit/413 (KHTML, like Gecko) Safari/413 Mozilla/5.0 (SymbianOS/9.2; U; Series60/3.1 NOKIAN95 8GB/1.0; |http://nds1.nds.nokia.com/uaprof/NN95-1r100.xml
+Mozilla/5.0 (Linux; U; Android 2.3.3; fi-fi; HTC_WildfireS_A510e Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www.htcmms.com.tw/Android/Common/PG76/ua-profile.xml
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.10222/26.984; U; ar) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone2,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.3;FBSS/1; FBCR/vodafoneUK;FBID/phone;FBLC/en_US;FBSF/1.0]|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.1;FBBV/4010.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/5.0;FBSS/2; FBCR/OrangeUK;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Dalvik/1.4.0 (Linux; U; Android 2.3.3; SBM006SH Build/S0038)|
+Mozilla/5.0 (iPad; U; CPU OS 4_3_3 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Mobile/8J2 Safari/528.16 Kikin/1.5.0|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[2693482802] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+SAMSUNG-C5212/C5212JPJK2 NetFront/3.4 Profile/MIDP-2.0 Configuration/CLDC-1.1|http://wap.samsungmobile.com/uaprof/C5212.xml
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.18154/26.984; U; tr) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (iPad; U; CPU OS 4_3_3 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Mobile/8J2 Safari/525.20|
+Mozilla/5.0 (Linux; U; Android 2.2.2; zh-cn; Dell Streak Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (Linux; U; Android 2.2; fr-fr; HTC Desire Build/FRF91) AppleWebKit/525.10+ (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2 (AdMob-ANDROID-20091123)|
+LG-KS660 Teleca/WAP2.0 Mï¿¿DP-2.0/CLDC-1.1|http://gsm.lge.com/html/gsm/LG-KS660.xml
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_1 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.1;FBSS/2; FBCR/Etisalat;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Dalvik/1.4.0 (Linux; U; Android 2.3.7; GT540 Build/GRI40)|http://gsm.lge.com/html/gsm/GT540_M6_D2_CL.xml
+Dalvik/1.2.0 (Linux; U; Android 2.2.1; Milestone Build/R.U.R.1920)|http://uaprof.motorola.com/phoneconfig/motoa853/Profile/motoa853.rdf
+Mozilla/5.0 (Linux; U; Android 2.1-update1; en-au; MB511 Build/RUTEM_U3_01.14.6) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_5 like Mac OS X; it_IT) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone2,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.5;FBSS/1; FBCR/Carrier;FBID/phone;FBLC/it_IT;FBSF/1.0]|
+Dalvik/1.2.0 (Linux; U; Android 2.2.1; XT720 Build/STSKT_N_79.33.50R)|http://gsm.lge.com/html/gsm/P990-M3-D2.xml
+Dalvik/1.2.0 (Linux; U; Android 2.2.2; GSmart G1310 Build/FRG83G)|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Dalvik/1.4.0 (Linux; U; Android 2.3.3; ST18a Build/4.0.A.2.368)|
+Dalvik/1.4.0 (Linux; U; Android 2.3.7; SPH-D700 Build/GRJ22)|http://device.sprintpcs.com/Samsung/SPH-D700/DI07.rdf
+SonyEricssonW395/R1FB Browser/OpenWave/1.0 Profile/MIDP-2.1 Configuration/CLDC-1.1, SonyEricssonW395/R1FB Browser/OpenWave/1.0 Profile/MIDP-2.1 Configuration/CLDC-1.1, SonyEricssonW395/R1FB Browser/OpenWave/1.0 Profile/MIDP-2.1 Configuration/CLDC-1.1, SonyEricssonW395/R1FB Browser/OpenWave/1.0 Profile/MIDP-2.1 Configuration/CLDC-1.1, SonyEricssonW395/R1FB Browser/OpenWave/1.0 Profile/MIDP-2.1 Configuration/CLDC-1.1, SonyEricssonW395/R1FB Browser/OpenWave/1.0 Profile/MIDP-2.1 Configuration/CLDC-1.1, SonyEric|http://www.sonyericsson.com/downloads/W395R101.xml
+Dalvik/1.1.0 (Linux; U; Android 2.1-update1; MB511 Build/RUTLA_U3_00.60.101)|
+Mozilla/5.0 (Linux; U; Android 2.1-update1; ar-eg; HTC Magic Build/ERE27) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17|http://www.google.com/oha/rdf/ua-profile-kila.xml
+Mozilla/4.0 SonyEricssonK850iv/R1CA|http://wap.sonyericsson.com/UAprof/K850iR101.xml
+SonyEricssonT700/R3EF Browser/NetFront/3.4 Profile/MIDP-2.1 Configuration/CLDC-1.1 JavaPlatform/JP-8.3.3|http://wap.sonyericsson.com/UAprof/T700R101.xml
+Dalvik/1.4.0 (Linux; U; Android 2.3.7; A953 Build/GWK74)|
+Mozilla/5.0 (SymbianOS/9.2; U; Series60/3.1 NOKIAN95 8GB/1.0; Profile/MIDP-2.0 Configuration/CLDC-1.1) AppleWebKit/413 (KHTML, like Gecko) Safari/413 Mozilla/5.0 (SymbianOS/9.2; U; Series60/3.1 NOKIAN95 8GB/1.0; Profile/MIDP-2.0 Configuration/CLDC-1.1) AppleWebKit/413 (KHTML, like Gecko) Safari/413 Mozilla/5.0 (SymbianOS/9.2; U; Series60/3.1 NOKIAN95 8GB/1.0; Profile/MIDP-2.0 Configuration/CLDC-1.1) AppleWebKit/413 (KHTML, like Gecko) Safari/413 Mozilla/5.0 (SymbianOS/9.2; U; Series60/3.1 NOKIAN95 8GB/1.0; |http://nds1.nds.nokia.com/uaprof/NN95-1r100.xml
+Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; Desire HD Build/MIUI) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://uaprof.vtext.com/adr62k/adr62k.xml
+Mozilla/5.0 (Linux; U; Android 1.1.5; fr-fr; A101B2-LZ Build/ECLAIR) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17|
+Opera/9.80 (J2ME/MIDP; Opera Mini/5.3521/26.984; U; tr) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; fr_FR) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.3;FBSS/2; FBCR/TELUS;FBID/phone;FBLC/fr_FR;FBSF/2.0]|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_2_1 like Mac OS X; de_DE) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone2,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.2.1;FBSS/1; FBCR/Telekom.de;FBID/phone;FBLC/de_DE;FBSF/1.0]|
+Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S8500/S8500JPJF4; U; Bada/1.0; fr-fr) AppleWebKit/533.1 (KHTML, like Gecko) Dolfin/2.0 Mobile WVGA SMM-MMS/1.2.0 OPN-B|http://wap.samsungmobile.com/uaprof/GT-S8500_3G.rdf
+Dalvik/1.1.0 (Linux; U; Android 2.1-update1; MB502 Build/BASEM_U3_01.12.4)|
+Dalvik/1.2.0 (Linux; U; Android 2.2.1; GT-S5570B Build/FROYO)|http://gsm.lge.com/html/gsm/P990-M3-D2.xml
+Mozilla/5.0 (Linux; U; Android 2.3.5; en-gb; GT-I9000 Build/MIUI) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://wap.samsungmobile.com/uaprof/GT-i9000.xml
+Opera/9.80 (Windows Mobile; Opera Mini/5.1.21594/26.984; U; pt) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[9083397752] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.3.24492/26.984; U; en) Presto/2.8.119 Version/10.54|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.1.14287/26.984; U; id) Presto/2.8.119 Version/10.54|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.16007/26.984; U; en) Presto/2.8.119 Version/10.54|
+Opera/9.80 (Android 1.6; Linux; Opera Mobi/ADR-1110071847; U; en) Presto/2.9.201 Version/11.50|
+Mozilla/5.0 (iPod touch; U; CPU iPhone OS 5_0 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPod4,1;FBMD/iPod touch;FBSN/iPhone OS;FBSV/5.0;FBSS/2; FBCR/;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; ar_AR) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.1;FBBV/4010.0;FBDV/iPhone2,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.3;FBSS/1; FBCR/Vodafone;FBID/phone;FBLC/ar_AR;FBSF/1.0]|
+Dalvik/1.4.0 (Linux; U; Android 2.3.4; GT-S5670 Build/GINGERBREAD)|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Mozilla/5.0 (SymbianOS/9.2; U; Series60/3.1 NokiaE63-3/200.21.012; Profile/MIDP-2.0 Configuration/CLDC-1.1) AppleWebKit/413 (KHTML, like Gecko) Safari/413|http://nds1.nds.nokia.com/uaprof/NE63-3r100.xml
+Opera/9.80 (Android 3.2.1; Linux; Opera Tablet/ADR-1110071847; U; en) Presto/2.9.201 Version/11.50|
+Opera/9.80 (Android 2.2; Linux; Opera Mobi/ADR-1110071847; U; nl) Presto/2.9.201 Version/11.50|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[3046140517] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (Linux; U; Android 2.3.3; sk-sk; HTC_WildfireS_A510e Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www.htcmms.com.tw/Android/Common/PG76/ua-profile.xml
+BlackBerry8310/4.5.0.187 Profile/MIDP-2.0 Configuration/CLDC-1.1 VendorID/161|http://www.blackberry.net/go/mobile/profiles/uaprof/8310/4.2.2.rdf
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0;FBBV/4000.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.3;FBSS/2; FBCR/OrangeUK;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Mozilla/5.0 (Linux; U; Android 2.2.2; de-de; MB860 Build/Blur_Version.4.4.20.MB860.Retail.en.DE Flex/P023) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_2_1 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.1;FBBV/4010.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.2.1;FBSS/2; FBCR/vodafoneUK;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Dalvik/1.4.0 (Linux; U; Android 2.3.7; IDEOS X5 Build/GRJ22)|
+gt-s5233w/UC Browser7.9.0.102/69/444 UNTRUSTED/1.0|
+Mozilla/5.0 (Linux; U; Android 2.3.4; hu-hu; GT-S5570 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14386/26.984; U; ar) Presto/2.8.119 Version/10.54|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.12814/26.984; U; es) Presto/2.8.119 Version/10.54|
+Blackberry 9700/5.0.0.862 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/609|http://www.blackberry.net/go/mobile/profiles/uaprof/9700_umts/5.0.0.rdf
+sgh-f480/UC Browser7.9.0.102/69/352 UNTRUSTED/1.0|
+Mozilla/5.0 (Linux; U; Android 2.3.2; pl-pl; SonyEricssonR800iv Build/3.0.A.2.184) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Dalvik/1.2.0 (Linux; U; Android 2.2.1; Milestone Build/SHOLS_U2_05.26.4)|http://uaprof.motorola.com/phoneconfig/motoa853/Profile/motoa853.rdf
+Mozilla/5.0 (iPod touch; U; CPU iPhone OS 4_2_1 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPod4,1;FBMD/iPod touch;FBSN/iPhone OS;FBSV/4.2.1;FBSS/2; FBCR/;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Mozilla/5.0 (Linux; U; Android 2.3.3; en-fr; HTC_DesireS_S510e Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www.htcmms.com.tw/Android/Common/PG88/ua-profile.xml
+Dalvik/1.2.0 (Linux; U; Android 2.2.2; LG-KU3700 Build/FRG83G)|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.3;FBSS/2; FBCR/vodaAU;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Mozilla/5.0 (Linux; U; Android 2.3.3; en-id; Desire HD Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www.htcmms.com.tw/Android/Common/PG88/ua-profile.xml
+Mozilla/5.0 (Series40; NokiaC2-02/06.96; Profile/MIDP-2.1 Configuration/CLDC-1.1) Gecko/20100401 S40OviBrowser/1.0.2.26.8|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_2 like Mac OS X; en-gb) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8H7 Safari/6533.18.5 Cydia/1.1.2 CyF/550.58|
+Nokia6310i/1.0 (4.06) Profile/MIDP-1.0 Configuration/CLDC-1.0|http://nds.nokia.com/uaprof/N6310r100.xml
+Dalvik/1.4.0 (Linux; U; Android 2.3.4; ME525+ Build/4.5.2-109_DHT-17)|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Opera/9.80 (Android 2.3.1; Linux; Opera Mobi/ADR-1110071847; U; fr) Presto/2.9.201 Version/11.50|http://wap.sonyericsson.com/UAprof/LT15iR301.xml
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; sv_SE) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.1;FBBV/4010.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.3;FBSS/2; FBCR/TELIA;FBID/phone;FBLC/sv_SE;FBSF/2.0]|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone4,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/5.0;FBSS/2; FBCR/O2;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Opera/9.80 (Android 2.2; Linux; Opera Mobi/ADR-1110071847; U; it) Presto/2.9.201 Version/11.50|
+Mozilla/5.0 (Linux; U; Android 2.3.6; ko-kr; SHV-E160S Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (Linux; U; Android 2.3.7; en-us; HTC Desire Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://uaprof.vtext.com/adr62k/adr62k.xml
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0 like Mac OS X; de_DE) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/5.0;FBSS/2; FBCR/Vodafone.de;FBID/phone;FBLC/de_DE;FBSF/2.0]|
+Mozilla/5.0 (Linux; U; Android 2.3.3; ko-kr; SHW-M250S Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 NAVER(inapp; search; 101; 3.0.2)|
+Dalvik/1.4.0 (Linux; U; Android 2.3.4; SHW-M250L Build/4.5.2A-KT-75)|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Mozilla/5.0 (Linux; U; Android 1.6; en-us; E10i Build/1.1.A.0.8) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1|http://wap.sonyericsson.com/UAprof/E10iR102.xml
+Blackberry9780/6.0.0.294 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/-1|http://www.blackberry.net/go/mobile/profiles/uaprof/9780/6.0.0.rdf
+Mozilla/5.0 (Linux; U; Android 2.3.3; en-au; SonyEricssonST18i Build/4.0.A.2.368) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_2_1 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone2,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.2.1;FBSS/1; FBCR/OrangeUK;FBID/phone;FBLC/en_US;FBSF/1.0]|
+Mozilla/5.0 (iPod touch; U; CPU iPhone OS 4_2_1 like Mac OS X; bg_BG) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/3.5a;FBBV/3500;FBDV/iPod3,1;FBMD/iPod touch;FBSN/iPhone OS;FBSV/4.2.1;FBSS/1; FBCR/;FBID/phone;FBLC/bg_BG]|
+Mozilla/5.0 (Linux; U; Android 2.3.3; en-nl; HTC Sensation Z710e Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_4 like Mac OS X; de_DE) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.4;FBSS/2; FBCR/Carrier;FBID/phone;FBLC/de_DE;FBSF/2.0]|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_5 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone2,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.5;FBSS/1; FBCR/O2;FBID/phone;FBLC/en_US;FBSF/1.0]|
+Mozilla/5.0 (Linux; U; Android 2.1-update1; en-in; SonyEricssonU20i Build/2.0.2.A.0.24) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17|http://wap.sonyericsson.com/UAprof/U20iR202.xml
+Mozilla/5.0 (Linux; U; Android 2.2.1; ja-jp; SBM003SH Build/S1900) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://gsm.lge.com/html/gsm/P990-M3-D2.xml
+NokiaX3-00/5.0 (08.54) Profile/MIDP-2.1 Configuration/CLDC-1.1 nokiax3-00/UC Browser7.9.0.102/70/352 UNTRUSTED/1.0|http://nds1.nds.nokia.com/uaprof/NX3-00r100.xml
+Mozilla/5.0 (Linux; U; Android 2.3.3; ko-kr; HTC_S710E Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Opera/9.80 (iPhone; Opera Mini/6.1.15738/26.984; U; nb) Presto/2.8.119 Version/10.54|
+Dalvik/1.4.0 (Linux; U; Android 2.3.5; Droid Build/MIUI-1.9.16.0-SHOLES-EN)|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.22892/26.984; U; en) Presto/2.8.119 Version/10.54|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.9751/26.984; U; id) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Linux; U; Android 2.2; fr-fr; LG-P500 Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (Linux; U; Android 2.1-update1; vi-vn; X10i Build/2.1.A.0.435) AppleWebKit/525.10+ (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2 (AdMob-ANDROID-20091123)|http://wap.sonyericsson.com/UAprof/X10iR201.xml
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_2_1 like Mac OS X; de_DE) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.1;FBBV/4010.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.2.1;FBSS/2; FBCR/Carrier;FBID/phone;FBLC/de_DE;FBSF/2.0]|
+Dalvik/1.1.0 (Linux; U; Android 2.1-Strabors-Mod-2.1.3; ZTE Racer Build/ERE27)|
+Opera/9.80 (Android 2.3.7; Linux; Opera Mobi/ADR-1110071847; U; de) Presto/2.9.201 Version/11.50|
+Mozilla/5.0 (Series40; Nokia5310XpressMusic/10; Profile/MIDP-2.1 Configuration/CLDC-1.1) Gecko/20100401 S40OviBrowser/1.4.0.34.8|http://nds1.nds.nokia.com/uaprof/N5310XpressMusicr100.xml
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; HTC Aria Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 androidAppVersion/2.1 AndroidWebkitWrapper|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 ( ; U; CPU iPhone OS 4_3_3 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8J2 Safari/6533.18.5|
+Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; HTC Glacier Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Dalvik/1.4.0 (Linux; U; Android 2.3.6; Nexus One Build/MOG)|
+iPhone - Safari 528.16 (iPhone OS 3.0)|
+Mozilla/5.0 (Linux; U; Android 2.3.3; de_de) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Ninesky/1.7.0 Safari/533.1|
+Mozilla/5.0 (iPad; U; CPU iPhone OS 4_3_3 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0;FBBV/4000.0;FBDV/iPad1,1;FBMD/iPad;FBSN/iPhone OS;FBSV/4.3.3;FBSS/1; FBCR/;FBID/tablet;FBLC/en_US;FBSF/1.0]|
+Dalvik/1.2.0 (Linux; U; Android 2.2; X06HT Build/FRF91)|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14881/26.984; U; es) Presto/2.8.119 Version/10.54|
+Nokia2690/10.10|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0 like Mac OS X; de_DE) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/3.5a;FBBV/3500;FBDV/iPhone2,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/5.0;FBSS/1; FBCR/Telekom.de;FBID/phone;FBLC/de_DE]|
+Mozilla/5.0 (Linux; U; Android 2.1-update1; sr-rs; GT-I9000 Build/ECLAIR) AppleWebKit/525.10+ (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2 (AdMob-ANDROID-20091123)|http://wap.samsungmobile.com/uaprof/GT-i9000.xml
+Dalvik/1.4.0 (Linux; U; Android 2.3.5; Desire HD Build/GRI40)|http://uaprof.vtext.com/adr62k/adr62k.xml
+Mozilla/5.0 (Series40; Nokia5330-1d/06.88; Profile/MIDP-2.1 Configuration/CLDC-1.1) Gecko/20100401 S40OviBrowser/1.4.0.34.8|http://nds1.nds.nokia.com/uaprof/N5330-1dr100.xml
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.13227/26.984; U; en) Presto/2.8.119 Version/10.54|
+Dalvik/1.2.0 (Linux; U; Android 2.2.2; MB525 Build/JEM_3.4.3-36-1.1)|http://uaprof.motorola.com/phoneconfig/MotoMB525/profile/MotoMB525.rdf
+Dalvik/1.2.0 (Linux; U; Android 2.2.1; iDx7 Build/FROYO)|http://gsm.lge.com/html/gsm/P990-M3-D2.xml
+SonyEricssonJ10i2/R7CA|http://wap.sonyericsson.com/UAprof/J10i2R101.xml
+Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; Nexus One Build/GRJ71) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Dalvik/1.4.0 (Linux; U; Android 2.3.5; HTC Desire S Build/GRJ22)|http://uaprof.vtext.com/adr62k/adr62k.xml
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_2 like Mac OS X; de_DE) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.2;FBSS/2; FBCR/Telekom.de;FBID/phone;FBLC/de_DE;FBSF/2.0]|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_0_1 like Mac OS X; de_DE) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.0.1;FBSS/2; FBCR/Telekom.de;FBID/phone;FBLC/de_DE;FBSF/2.0]|
+Mozilla/5.0 (aYeN; U; CPU iPhone OS 4_2_1 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8C148 Safari/6533.18.5|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_5 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.1;FBBV/4010.0;FBDV/iPhone2,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.5;FBSS/1; FBCR/3;FBID/phone;FBLC/en_US;FBSF/1.0]|
+NokiaC1-01/2.0 (04.40) Profile/MIDP-2.1 Configuration/CLDC-1.1 nokiac1-01/UC Browser7.8.0.95/69/352 UNTRUSTED/1.0|
+Dalvik/1.4.0 (Linux; U; Android 2.3.4; DROID BIONIC Build/5.5.1_84_DBN-91-LaunchKit)|
+Opera/9.80 (J2ME/MIDP; Opera Mini/5.22349/26.984; U; en) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; ar_AR) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.3;FBSS/2; FBCR/ZainKW;FBID/phone;FBLC/ar_AR;FBSF/2.0]|
+Dalvik/1.4.0 (Linux; U; Android 2.3.4; GT-S5830D Build/GINGERBREAD)|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+NokiaX3-00/5.0 (11.00) Profile/MIDP-2.1 Configuration/CLDC-1.1 nokiax3-00/UC Browser7.6.1.82/69/352 UNTRUSTED/1.0|http://nds1.nds.nokia.com/uaprof/NX3-00r100.xml
+Mozilla/5.0 (iPhone; CPU iPhone OS 5_0 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) 1Password/3.6.1/361005 (like Mobile/8C148 Safari/6533.18.5)|
+NokiaC1-01/2.0 (05.40) Profile/MIDP-2.1 Configuration/CLDC-1.1 nokiac1-01/UC Browser7.9.0.102/70/352|
+Dalvik/1.4.0 (Linux; U; Android 2.3.4; FIH-FB0 Build/GRJ22)|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Dalvik/1.4.0 (Linux; U; Android 2.3.4; MB526 Build/4.5.1_128)|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Mozilla/5.0 (Linux; U; Android 2.2.2; ko; LG-P970 Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 MMS/LG-Android-MMS-V1.0/1.2|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+gt-s5233s UNTRUSTED/1.0 UNTRUSTED/1.0|
+Nokia5310XpressMusic/2.0 (10.10) Profile/MIDP-2.1 Configuration/CLDC-1.1 nokia5310xpressmusic/UC Browser7.0.0.41/69/352 UNTRUSTED/1.0|http://nds1.nds.nokia.com/uaprof/N5310XpressMusicr100.xml
+Mozilla/5.0 (Linux; U; Android 2.3.4; ko-kr; LG-KU3700 Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 MMS/LG-Android-MMS-V1.0/1.2|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone2,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/5.0;FBSS/1; FBCR/AT&T;FBID/phone;FBLC/en_US;FBSF/1.0]|
+Mozilla/5.0 (Linux; U; Android 2.3.3; zh-tw; SonyEricssonR800i Build/3.0.1.A.0.145) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (Linux; U; Android 2.3.4; da-us; pcdadr6350 Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.1.11313/26.984; U; es) Presto/2.8.119 Version/10.54|
+Blackberry 9700/6.0.0.570 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/100|http://www.blackberry.net/go/mobile/profiles/uaprof/9700_umts/5.0.0.rdf
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_2 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.1;FBBV/4010.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.2;FBSS/2; FBCR/AT|
+Dalvik/1.2.0 (Linux; U; Android 2.2.2; MB860 Build/OLYLA_U4_0.54.0_R01)|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_2_1 like Mac OS X; de_DE) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/3.5a;FBBV/3500;FBDV/iPhone2,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.2.1;FBSS/1; FBCR/Telekom.de;FBID/phone;FBLC/de_DE]|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_5 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Mobile/8L1 HPSwissKnife/4.0|
+Mozilla/5.0 (Linux; U; Android 2.3.5; en-au; GT-I9100 Build/MIUI) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (iPad; U; CPU iPhone OS 4_3_4 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPad2,1;FBMD/iPad;FBSN/iPhone OS;FBSV/4.3.4;FBSS/1; FBCR/;FBID/tablet;FBLC/en_US;FBSF/1.0]|
+Blackberry 9700/6.0.0.448 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/327|http://www.blackberry.net/go/mobile/profiles/uaprof/9700_umts/5.0.0.rdf
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[7408566616] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; Droid Build/MIUI-1.10.7.0-SHOLES-EN) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.22228/26.984; U; sr) Presto/2.8.119 Version/10.54|
+Dalvik/1.2.0 (Linux; U; Android 2.2.2; LG-P500h Build/FRG83)|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (BlackBerry; U; BlackBerry 9790; en-US) AppleWebKit/534.11+ (KHTML, like Gecko) Version/7.0.0.473 Mobile Safari/534.11+|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.13067/26.984; U; es) Presto/2.8.119 Version/10.54|
+BlackBerry9700/5.0.0.586 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/610|http://www.blackberry.net/go/mobile/profiles/uaprof/9700_umts/5.0.0.rdf
+Dalvik/1.4.0 (Linux; U; Android 2.3.5; YP-G70 Build/GINGERBREAD)|
+SonyEricssonK600i/R2BB Browser/SEMC-Browser/4.2 Profile/MIDP-2.0 Configuration/CLDC-1.1|http://wap.sonyericsson.com/UAprof/K600iR101.xml
+Mozilla/5.0 (iPad; U; CPU iPhone OS 4_3_3 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPad1,1;FBMD/iPad;FBSN/iPhone OS;FBSV/4.3.3;FBSS/1; FBCR/;FBID/tablet;FBLC/en_US;FBSF/1.0]|
+Mozilla/5.0 (Linux; U; Android 2.3.5; de-de; HTC HD2 Build/MIUI) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Opera/9.80 (J2ME/MIDP; Opera Mini/5.1.21566/26.984; U; pt) Presto/2.8.119 Version/10.54|
+Opera/9.80 (J2ME/MIDP; Opera Mini/5.1.24321/26.984; U; es) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Linux; U; Android 2.3.3; ko-kr) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[7572012100] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Dalvik/1.4.0 (Linux; U; Android 2.3.5; TripNMiUI Pyramid Build/S01031B.1.10.14-TripNRaVeR)|
+Mozilla/5.0 (Linux; U; Android 2.3.3; en-gb; pcdadr6350 Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[8704947881] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (Linux; U; Android 3.2; ko-kr; SHW-M380W Build/HTJ85B) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13|
+AppleCoreMedia/1.0.0.9A334 (iPod; U; CPU OS 5_0 like Mac OS X; en_us)|
+Dalvik/1.4.0 (Linux; U; Android 2.3.7; SGH-I777 Build/GWK74)|
+Dalvik/1.4.0 (Linux; U; Android 2.3.5; PG86100 Build/MIUI)|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-au; Liquid Metal Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://support.acer.com/UAprofile/Acer_S100_Profile.xml
+Mozilla/5.0 (BlackBerry; U; BlackBerry 9810; en) AppleWebKit/534.11  (KHTML, like Gecko) Version/7.0.0.317 Mobile Safari/534.11|
+Mozilla/5.0 (Linux; U; Android 2.2.2; ko-kr; SCH-i909 Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (iPad; CPU OS 5_0 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Mobile/9A334 Zite/1.2|
+Opera/9.80 (J2ME/MIDP; Opera Mini/5.20952/26.984; U; es) Presto/2.8.119 Version/10.54|
+Opera/9.50 (J2ME/MIDP; Opera Mini/4.2.19923/25.852; U; es)|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.1.13685/26.984; U; ar) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.3;FBSS/2; FBCR/Telstra;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Mozilla/5.0 (m.arce02â?¥; U; CPU iPhone OS 4_3_1 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8G4 Safari/6533.18.5|
+Mozilla/5.0 (Linux; U; Android 3.2; de-de; Sony Tablet S Build/THMAS11000) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[2012806883] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Opera/9.80 (J2ME/MIDP; Opera Mini/5.18487/26.984; U; es) Presto/2.8.119 Version/10.54|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.1.13907/26.984; U; es) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Linux; U; Android 2.3.2; ru-ru; SonyEricssonLT15i Build/3.0.A.2.184) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_0_2 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.0.2;FBSS/2; FBCR/AT|
+Opera/9.80 (BREW; Opera Mini/5.16/24.1029; U; en) Presto/2.5.25 480X800 LG VX11000H-U660|
+Mozilla/5.0 (Linux; U; Android 2.3.4; es-es; MT11i Build/4.0.1.A.0.283) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Blackberry8520/5.0.0.681 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/298|http://www.blackberry.net/go/mobile/profiles/uaprof/8520_80211g/4.6.1.rdf
+Mozilla/5.0 (Linux; U; Android 2.3.7; en-us; SGH-I777 Build/GWK74) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_2_1 like Mac OS X; de_DE) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.2.1;FBSS/2; FBCR/Carrier;FBID/phone;FBLC/de_DE;FBSF/2.0]|
+Opera/9.80 (S60; SymbOS; Opera Mobi/SYB-1107071604; U; sr) Presto/2.8.149 Version/11.10|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_2 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.2;FBSS/2; FBCR/AT|
+Opera/9.80 (Android 2.1-update1; Linux; Opera Mobi/ADR-1110071847; U; es-ES) Presto/2.9.201 Version/11.50|http://wap1.huawei.com/uaprof/HuaweiU8230v100WCDMAEclair.xml
+BlackBerry9300/5.0.0.758 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/136|http://www.blackberry.net/go/mobile/profiles/uaprof/9300_umts/5.0.0.rdf
+Mozilla/5.0 (Linux; U; Android 1.6; fr-fr; HTC Tattoo Build/DRC79) AppleWebKit/528.5  (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1|http://www.htcmms.com.tw/Android/Common/Tattoo/ua-profile.xml
+SAMSUNG-GT-C5010E/C5010EZHKE1 NetFront/3.5 Profile/MIDP-2.0 Configuration/CLDC-1.1|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[8068918312] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (BlackBerry; U; BlackBerry 9780; pl) AppleWebKit/534.8+ (KHTML, like Gecko) Version/6.0.0.576 Mobile Safari/534.8+|http://www.blackberry.net/go/mobile/profiles/uaprof/9780/6.0.0.rdf
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_5 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0;FBBV/4000.0;FBDV/iPhone2,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.5;FBSS/1; FBCR/AT|
+Dalvik/1.4.0 (Linux; U; Android 2.3.4; Nexus One Build/MIUI)|
+Opera/9.80 (BlackBerry; Opera Mini/4.3.25172/26.984; U; en) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; HTC Glacier Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 BingWeb/2.1.570.20110929|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.10247/26.984; U; tr) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Linux; U; Android 2.1-update1; nl-nl; GT-I5500 Build/ERE27) AppleWebKit/525.10+ (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2 (AdMob-ANDROID-20091123)|
+Opera/9.80 (J2ME/MIDP; Opera Mini/5.22371/26.984; U; en) Presto/2.8.119 Version/10.54n/10.54|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0 like Mac OS X; ar_AR) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/5.0;FBSS/2; FBCR/Etisalat;FBID/phone;FBLC/ar_AR;FBSF/2.0]|
+Mozilla/5.0 (BlackBerry; U; BlackBerry 9900; en-GB) AppleWebKit/534.11+ (KHTML, like Gecko) Version/7.0.0.440 Mobile Safari/534.11+|
+Mozilla/5.0 (iPad; U; CPU iPhone OS 4_3_1 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPad2,1;FBMD/iPad;FBSN/iPhone OS;FBSV/4.3.1;FBSS/1; FBCR/;FBID/tablet;FBLC/en_US;FBSF/1.0]|
+Dalvik/1.5.1 (Linux; U; Android 3.2; tegav2 Build/HTJ85B)|
+Dalvik/1.4.0 (Linux; U; Android 2.3.3; XT316 Build/GRI40)|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_0 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/3.5a;FBBV/3500;FBDV/iPhone1,2;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.0;FBSS/1; FBCR/AT|
+Opera/9.80 (J2ME/MIDP; Opera Mini/5.22371/26.984; U; en) Presto/2.8.119 Version/10.54544|
+Mozilla/5.0 (iPad; U; CPU iPhone OS 5_0 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPad2,2;FBMD/iPad;FBSN/iPhone OS;FBSV/5.0;FBSS/1; FBCR/vodafoneUK;FBID/tablet;FBLC/en_US;FBSF/1.0]|
+Nokia6230/2.0 (03.15) Profile/MIDP-2.0 Configuration/CLDC-1.1 (compatible; GROUP_ID=PG2100-Fitel/VER=1.00/BROWSER=ObigoQ03C/TCPIP=1.00/PIAFS=3.02C/MELODY=F/PSID=075103571/PSNO= 115120901124)|http://nds1.nds.nokia.com/uaprof/N6230r100.xml
+Opera/9.00 (Nintendo Wii; U; ; 1038-58; Wii Internet Channel/1.0; en)|
+Mozilla/5.0 (Linux; U; Android 2.1-update1; en-sk; HTC_Wildfire_A3333 Build/ERE27) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17|http://www.htcmms.com.tw/Android/Common/Wildfire/ua-profile.xml
+Mozilla/5.0 (Linux; U; Android 2.3.3; en-us; SonyEricssonSK17iv Build/4.0.A.2.335) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (P-DOG ;-); U; CPU iPhone OS 4_2_1 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8C148 Safari/6533.18.5|
+Mozilla/5.0 (Linux; U; Android 2.3.3; de-de; SonyEricssonST15i Build/4.0.A.2.368) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Opera/9.80 (BlackBerry; Opera Mini/4.3.26549/26.984; U; en) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Linux; U; Android 2.3.3; ru-; DROID2 Build/4.5.1_57_DR2-31) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+BlackBerry9000/5.0.0.510 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/179|http://www.blackberry.net/go/mobile/profiles/uaprof/9000/4.6.0.rdf
+Mozilla/5.0 (Linux; U; Android 2.3.3; en-bg; HTC_WildfireS_A510e Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www.htcmms.com.tw/Android/Common/PG76/ua-profile.xml
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[4043302300] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.9800/26.984; U; es) Presto/2.8.119 Version/10.54|
+Opera/9.80 (BlackBerry; Opera Mini/5.1.21216/26.984; U; en) Presto/2.8.119 Version/10.54|
+Dalvik/1.4.0 (Linux; U; Android 2.3.5; HTC Sensation kingdroid v7 sense 3.5 Build/GRJ90)|
+Mozilla/5.0 (SymbianOS/9.4; Series60/5.0 NokiaC6-00.1/41.2.010; Profile/MIDP-2.1 Configuration/CLDC-1.1) AppleWebKit/533.4 (KHTML, like Gecko) NokiaBrowser/7.3.1.31 3gpp-gba|
+Mozilla/5.0 (Linux; U; Android 3.0.1; en-gb; GtabComb Build/HRI66) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13|
+NokiaN97/UC Browser7.9.0.102/50/351/UCWEB|http://nds1.nds.nokia.com/uaprof/NN97r100-2G.xml
+Nokia7230/5.0 (10.82) Profile/MIDP-2.1 Configuration/CLDC-1.1 Mozilla/5.0 AppleWebKit/420  (KHTML, like Gecko) Safari/420|http://nds1.nds.nokia.com/uaprof/N7230r100.xml
+Dalvik/1.5.1 (Linux; U; Android 3.2; streak7 Build/HTJ85B)|
+Dalvik/1.4.0 (Linux; U; Android 2.3.4; Galaxy5 Build/GRI40)|http://wap.samsungmobile.com/uaprof/GT-i5700.xml
+Dalvik/1.2.0 (Linux; U; Android 2.2.2; Liquid Build/FRG83G)|http://support.acer.com/UAprofile/Acer_S100_Profile.xml
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_1 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone1,2;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.1;FBSS/1; FBCR/OrangeUK;FBID/phone;FBLC/en_US;FBSF/1.0]|
+Mozilla/5.0 (Linux; U; Android 2.3.4; da-dk; HTC Sensation Z710e Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Mozilla/5.0 (Linux; U; Android 2.2; zh-; GT-I9000 Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://wap.samsungmobile.com/uaprof/GT-i9000.xml
+Mozilla/5.0 (Linux; U; Android 2.2.2; es-us; SCH-M828C[2563053682] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (Linux; U; Android 1.6; es-us; T-Mobile myTouch 3G Build/DMD64) AppleWebKit/528.5  (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1|
+BlackBerry8900/5.0.0.1067 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/222|http://www.blackberry.net/go/mobile/profiles/uaprof/8900_80211g/4.6.1.rdf
+Mozilla/5.0 (Linux; U; Android 2.3.4; ko-kr; GT-S5830L Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.18887/26.984; U; es) Presto/2.8.119 Version/10.54|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.16402/26.984; U; fr) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (compatible; OSS/1.0; Chameleon; Linux) U9/R6632_G_81.11.1AI BER/2.0 Profile/MIDP-2.0 Configuration/CLDC-1.1|
+Dalvik/1.4.0 (Linux; U; Android 2.3.5; M860 Build/GRJ90)|
+Mozilla/5.0 (Linux; U; Android 2.3.3; de-at; SonyEricssonST18i Build/4.0.A.2.368) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (Linux; U; Android 2.3.4; en-gb; GT-I9100G Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[5178030618] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[2055206767] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_2 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.2;FBSS/2; FBCR/Etisalat;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Mozilla/5.0 (Linux; U; Android 2.3.3; en-us; DROID X2 Build/4.5.1_57_DX5-32) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Opera/9.80 (J2ME/MIDP; Opera Mini; U; es) Presto/2.8.119 Version/10.54119 Version/10.54|
+Mozilla/5.0 (Linux; U; Android 2.3.3; de-ch; HTC Vision Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Dalvik/1.5.0 (Linux; U; Android 3.0.1; Flashback 7.2 Build/HRI66)|
+Mozilla/5.0 (Linux; U; Android 3.0.1; zh-tw; A501 Build/HRI66) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13|
+Mozilla/5.0 (iPad; U; CPU iPhone OS 5_0 like Mac OS X; ar_AR) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPad1,1;FBMD/iPad;FBSN/iPhone OS;FBSV/5.0;FBSS/1; FBCR/Carrier;FBID/tablet;FBLC/ar_AR;FBSF/1.0]|
+BlackBerry9000/5.0.0.743 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/205|http://www.blackberry.net/go/mobile/profiles/uaprof/9000/4.6.0.rdf
+Mozilla/5.0 (iPad; U; CPU iPhone OS 4_3_3 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPad2,2;FBMD/iPad;FBSN/iPhone OS;FBSV/4.3.3;FBSS/1; FBCR/Carrier;FBID/tablet;FBLC/en_US;FBSF/1.0]|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; de_DE) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone2,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.3;FBSS/1; FBCR/Telekom.de;FBID/phone;FBLC/de_DE;FBSF/1.0]|
+LG-GW300/V100 Obigo/WAP2.0 Profile/MIDP-2.0 ConfiguraET_SessionId=haio0r232vbh0yfyiorxrrvl|http://gsm.lge.com/html/gsm/LG-GW300.xml
+SAMSUNG-GT-B3210/1.0 Release/10.19.2009 Browser/NetFront3.5 Profile/MIDP-2.0 Configuration/CLDC-1.1/*MzU3Nzk3MDM5MTM2MzEy|http://wap.samsungmobile.com/uaprof/GT-B3210UAProf.xml
+Opera/9.80 (iPhone; Opera Mini/6.1.15738/26.984; U; ar) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Linux; U; Android 2.2.2; es-us; SCH-M828C[2242450905] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.3;FBSS/2; FBCR/Etisalat;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Mozilla/5.0 (Linux; U; Android 2.3.3; fi-fi; Desire HD Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www.htcmms.com.tw/Android/Common/PG88/ua-profile.xml
+Mozilla/5.0 (Series40; NokiaC3-00/08.65; Profile/MIDP-2.1 Configuration/CLDC-1.1) Gecko/20100401 S40OviBrowser/1.4.0.34.8|http://nds1.nds.nokia.com/uaprof/NokiaC3-00r100.xml
+RT320X240/M.RF4700201.M01001.V1.0/WAP2.0 Profile/MIDP-2.0 Configuration/CLDC-1.0 RT320X240/M.RF4700201.M01001.V1.0/WAP2.0 Profile/MIDP-2.0 Configuration/CLDC-1.0|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/5.0;FBSS/2; FBCR/Etisalat;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; MB865 Build/5.5.1-175_EDFFW1-16) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (iPad; U; CPU OS 3_2_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Mobile/7B500 Installous|
+Dalvik/1.2.0 (Linux; U; Android 2.2.2; MB525 Build/3.4.2-108_JDNL-2_R01)|http://uaprof.motorola.com/phoneconfig/MotoMB525/profile/MotoMB525.rdf
+BlackBerry9100/5.0.0.783 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/611|http://www.blackberry.net/go/mobile/profiles/uaprof/9100/4.6.0.rdf
+Opera/9.80 (iPad; Opera Mini/6.1.15738/26.984; U; ru) Presto/2.8.119 Version/10.54|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.9800/26.984; U; en) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Welcome 2 Stunnaville; U; CPU iPhone OS 4_3_3 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8J2 Safari/6533.18.5|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; da_DK) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/3.5a;FBBV/3500;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.3;FBSS/2; FBCR/TELIA;FBID/phone;FBLC/da_DK]|
+Mozilla/5.0 (Linux; U; Android 2.2.2; es-us; MB612 Build/KRNS-X4-1.1.10) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (Linux; U; Android 2.1-update1; fr-fr; GT-I5800 Build/ECLAIR) AppleWebKit/525.10+ (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2 (AdMob-ANDROID-20091123)|http://wap.samsungmobile.com/uaprof/GT-i5800.xml
+Dalvik/1.2.0 (Linux; U; Android 2.2.1; ckt16_a10y Build/MASTER)|http://gsm.lge.com/html/gsm/P990-M3-D2.xml
+Opera/9.80 (BlackBerry; Opera Mini/5.1.22303/26.984; U; ar) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Linux; U; Android 1.6; fr-fr; X10i Build/R2BA026) AppleWebKit/525.10+ (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2 (AdMob-ANDROID-20091123)|http://wap.sonyericsson.com/UAprof/X10iR101.xml
+Mozilla/5.0 (Linux; U; Android 2.2.2; zh-cn; SGH-T589R Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (Linux; U; Android 1.6; fr-fr; E130 Build/Donut) AppleWebKit/525.10+ (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2 (AdMob-ANDROID-20091123)|
+Opera/9.80 (Android 2.2; Linux; Opera Tablet/ADR-1110071847; U; it) Presto/2.9.201 Version/11.50|
+Mozilla/5.0 (Linux; U; Android 2.3.3; ms-my; SonyEricssonSK17a Build/4.0.A.2.335) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[5095461741] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+SAMSUNG-GT-S3653/S3653JPJA2 SHP/VPP/R5 Jasmine/1.0 Nextreaming SMM-MMS/1.2.0 profile/MIDP-2.1 configuration/CLDC-1.1|http://wap.samsungmobile.com/uaprof/GT-S3653.rdf
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_5 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.5;FBSS/2; FBCR/Mobinil;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Mozilla/5.0 (Linux; U; Android 1.6; de-de; SonyEricssonE10i Build/1.2.A.1.174) AppleWebKit/528.5  (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1|http://wap.sonyericsson.com/UAprof/E10iR102.xml
+Dalvik/1.2.0 (Linux; U; Android 2.2.1; A853 Build/SHLA_U2_05.12.0)|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone2,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/5.0;FBSS/1; FBCR/Etisalat;FBID/phone;FBLC/en_US;FBSF/1.0]|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.1.13907/26.984; U; ru) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; IDEOS X5 Build/HuaweiU8800Pro) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.3.26550/26.984; U; en) Presto/2.8.119 Version/10.54|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.21648/2644; U; en) Presto/2.2.0Opera Mini/att/4.2.15814; U; en|
+NokiaC2-01/5.0 (10.50) Profile/MIDP-2.1 Configuration/CLDC-1.1 nokiac2-01/UC Browser7.8.0.95/70/350|http://nds1.nds.nokia.com/uaprof/NC2-01r100.xml
+Dalvik/1.2.0 (Linux; U; Android 2.2; Liquid Metal Build/MASTER)|http://support.acer.com/UAprofile/Acer_S100_Profile.xml
+Nokia6630/1.0 (4.03.38) SymbianOS/8.0 Series60/2.6 Profile/MIDP-2.0 Configuration/CLDC-1.1/UC Browser7.9.0.102/27/351/UCWEB|http://nds1.nds.nokia.com/uaprof/N6630r100.xml
+BlackBerry9520/5.0.0.973 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/136|http://www.blackberry.net/go/mobile/profiles/uaprof/9520_edge/5.0.0.rdf
+Mozilla/5.0 (BlackBerry; U; BlackBerry 9350; en-US) AppleWebKit/534.11  (KHTML, like Gecko) Version/7.0.0.400 Mobile Safari/534.11|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; ar_AR) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0;FBBV/4000.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.3;FBSS/2; FBCR/Carrier;FBID/phone;FBLC/ar_AR;FBSF/2.0]|
+Opera/9.80 (J2ME/MIDP; Opera Mini/5.1.24009/26.984; U; pl) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Linux; U; Android 2.2.1; fr-fr; GT-I9000 Build/FROYO) AppleWebKit/525.10+ (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2 (AdMob-ANDROID-20091123)|http://wap.samsungmobile.com/uaprof/GT-i9000.xml
+Mozilla/5.0 (Linux; U; Android 2.3.4; es-us; ADR6330VW Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Mozilla/5.0 (Linux; U; Android 3.2.1; es-es; Transformer TF101 Build/HTK75) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13|
+Mozilla/5.0 (SymbianOS/9.3; Series60/3.2 NokiaE5-00.2/042.014; Profile/MIDP-2.1 Configuration/CLDC-1.1 ) AppleWebKit/525 (KHTML, like Gecko) Version/3.0 BrowserNG/7.2.6.2|
+BlackBerry9000/5.0.0.1079 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/152|http://www.blackberry.net/go/mobile/profiles/uaprof/9000/4.6.0.rdf
+Opera/9.80 (Android; Opera Mini/5.1.21927/26.984; U; en) Presto/2.8.119 Version/10.54|
+Dalvik/1.2.0 (Linux; U; Android 2.2.2; XT800 Build/TITA_M2_17.19.0)|
+Mozilla/5.0 (Linux; U; Android 2.3.3; da-dk; Desire_A8181 Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www.htcmms.com.tw/Android/Common/PG88/ua-profile.xml
+Opera/9.80 (iPad; Opera Mini/6.13548/26.984; U; en) Presto/2.8.119 Version/10.54n/10.54|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 3_1_3 like Mac OS X; ar) AppleWebKit/528.18 (KHTML, like Gecko) Mobile/7E18 Twitter for iPhone|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_2 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.1;FBBV/4010.0;FBDV/iPhone2,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.2;FBSS/1; FBCR/AT&T;FBID/phone;FBLC/en_US;FBSF/1.0]|
+BlackBerry8300/4.5.0.176 Profile/MIDP-2.0 Configuration/CLDC-1.1 VendorID/100|http://www.blackberry.net/go/mobile/profiles/uaprof/8300/4.2.2.rdf
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/5.0;FBSS/2; FBCR/SingTel;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Dalvik/1.2.0 (Linux; U; Android 2.2; C510a Build/CN0BB411D7)|http://wap.sonyericsson.com/UAprof/C510aR101.xml
+Mozilla/4.0 (compatible; Nokia Podcasting; SymbianOS; Nokia6720c/012.008)|
+Opera/9.80 (Android; Opera Mini/5.1.22460/26.984; U; pl) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3;FBSS/2; FBCR/T-MobileUK;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Opera/9.80 (Android 2.2; Linux; Opera Tablet/ADR-1110071847; U; es-ES) Presto/2.9.201 Version/11.50|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.3.13337/26.984; U; en) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (BlackBerry; U; BlackBerry 9810; en-US) AppleWebKit/534.11  (KHTML, like Gecko) Version/7.0.0.254 Mobile Safari/534.11|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[9857917895] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (Linux; U; Android 2.3.3; es-us; DROID Pro Build/4.5.1-110-VNS-22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Dalvik/1.2.0 (Linux; U; Android 2.2.2; Nexus S Build/OLYKT_U4_1.15.0)|
+Dalvik/1.4.0 (Linux; U; Android 2.3.5; HTC Glacier Build/GRJ90)|
+Mozilla/5.0 (Linux; U; Android 2.3.3; en-us; ADR6300 Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.4/26.984; U; en) Presto/2.8.119 Version/10.54|
+Opera/9.80 (J2ME/MIDP; Opera Mini/9.80/26.984; U; es) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (BlackBerry; U; BlackBerry 9350; en-US) AppleWebKit/534.11+ (KHTML, like Gecko) Version/7.0.0.400 Mobile Safari/534.11+|
+Mozilla/5.0 (Linux; U; Android 2.3.4; es-us; SPH-D600 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Dalvik/1.4.0 (Linux; U; Android 2.3.4; Orange Monte Carlo Build/OAT_B05)|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Dalvik/1.4.0 (Linux; U; Android 2.3.4; LG Optimus 2X Build/GRJ22)|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Opera/9.80 (Android 3.2.2; Linux; Opera Tablet/ADR-1110071847; U; en) Presto/2.9.201 Version/11.50|
+Mozilla/5.0 (iPod touch; U; CPU iPhone OS 4_3_4 like Mac OS X; de_DE) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPod3,1;FBMD/iPod touch;FBSN/iPhone OS;FBSV/4.3.4;FBSS/1; FBCR/;FBID/phone;FBLC/de_DE;FBSF/1.0]|
+Mozilla/5.0 (Linux; U; Android 2.1-update1-v1.0; en-gb; HTC Hero Build/ERE27) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17|http://www.htcmms.com.tw/Android/TMO/Hero/ua-profile.xml
+Mozilla/5.0 (BlackBerry; U; BlackBerry 9300; zh-CN) AppleWebKit/534.8+ (KHTML, like Gecko) Version/6.0.0.668 Mobile Safari/534.8+|http://www.blackberry.net/go/mobile/profiles/uaprof/9300_umts/6.0.0.rdf
+Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; HTC; Radar; Orange)|http://device.sprintpcs.com/HTC/SPS511BK/latest
+SAMSUNG-GT-B3210/1.0 Release/10.19.2009 Browser/NetFront3.5 Profile/MIDP-2.0 Configuration/CLDC-1.1/*MzU4NjI4MDM2OTA2NjA2|http://wap.samsungmobile.com/uaprof/GT-B3210UAProf.xml
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/5.0;FBSS/2; FBCR/T-MobileUK;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Mozilla/5.0 (Linux; U; Android 2.2.1; fr-fr; GT-S5660 Build/FROYO) AppleWebKit/525.10+ (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2 (AdMob-ANDROID-20091123)|
+Mozilla/5.0 (Linux; U; Android 2.1-update1; fr-fr; GT-I5700 Build/ECLAIR) AppleWebKit/525.10+ (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2 (AdMob-ANDROID-20091123)|http://wap.samsungmobile.com/uaprof/GT-i5700.xml
+NokiaC1-01/2.0 (05.45) Profile/MIDP-2.1 Configuration/CLDC-1.1 Opera/9.60 (J2ME/MIDP;Opera Mini/4.2.13337Mod.by.Iyke./503; U; en)Presto/2.2.0 UNTRUSTED/1.0|
+Dalvik/1.2.0 (Linux; U; Android 2.2.1; MB300 Build/FRG83)|http://uaprof.motorola.com/phoneconfig/MotoMB300/profile/MotoMB300.rdf
+Mozilla/5.0 (Linux; U; Android 3.2; fr-fr; A501 Build/HTJ85B) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13|
+Dalvik/1.2.0 (Linux; U; Android 2.2.1; SHW-M180L Build/FROYO)|http://gsm.lge.com/html/gsm/P990-M3-D2.xml
+Nokia6700s/033.014 (SymbianOS/9.3; U; Series60/3.2; Mozilla/5.0; Profile/MIDP-2.1 Configuration/CLDC-1.1) AppleWebKit/525 (KHTML,like Gecko) Safari/525|http://nds1.nds.nokia.com/uaprof/N6700sr100.xml
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; sv_SE) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone2,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.3;FBSS/1; FBCR/TELIA;FBID/phone;FBLC/sv_SE;FBSF/1.0]|
+Mozilla/5.0 (Linux; U; Android 2.2; ko-kr; LG-E720 Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 MMS/LG-Android-MMS-V1.0/1.2|
+Mozilla/5.0 (Linux; U; Android 2.3.4; zh-hk; GT-S5830 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[8648387408] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.17766/26.984; U; en) Presto/2.8.119 Version/10.54|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.17766/26.984; U; en) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Linux; U; Android 1.6; en-us; SonyEricssonX10a Build/R2CA016) AppleWebKit/528.5  (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1 androidAppVersion/2.1 AndroidWebkitWrapper|http://wap.sonyericsson.com/UAprof/X10aR101.xml
+Mozilla/5.0 (Linux; U; Android 2.3.7; en-us; Incredible 2 Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Dalvik/1.2.0 (Linux; U; Android 2.2.1; SCH-i909 Build/FROYO)|http://gsm.lge.com/html/gsm/P990-M3-D2.xml
+Mozilla/5.0 (Linux; U; Android 2.3.3; fr-fr; Droid Build/FRG83D) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (iPod touch; U; CPU iPhone OS 4_2_1 like Mac OS X; es_ES) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPod2,1;FBMD/iPod touch;FBSN/iPhone OS;FBSV/4.2.1;FBSS/1; FBCR/;FBID/phone;FBLC/es_ES;FBSF/1.0]|
+BlackBerry9530/5.0.0.191 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/105|http://www.blackberry.net/go/mobile/profiles/uaprof/9530_umts/4.7.0.rdf
+BlackBerry8310/4.5.0.176 Profile/MIDP-2.0 Configuration/CLDC-1.1 VendorID/102 UP.Browser/5.0.3.3|http://www.blackberry.net/go/mobile/profiles/uaprof/8310/4.2.2.rdf
+BlackBerry8520/5.0.0.1007 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/373|http://www.blackberry.net/go/mobile/profiles/uaprof/8520_80211g/4.6.1.rdf
+Mozilla/5.0 (BlackBerry; U; BlackBerry 9800; ca) AppleWebKit/534.8+ (KHTML, like Gecko) Version/6.0.0.668 Mobile Safari/534.8+|http://www.blackberry.net/go/mobile/profiles/uaprof/9800_edge/6.0.0.rdf
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.13555/26.984; U; de) Presto/2.8.119 Version/10.54|
+NOKIAN85/UC Browser7.7.1.88/28/351|http://nds1.nds.nokia.com/uaprof/NN85-1r100.xml
+Dalvik/1.2.0 (Linux; U; Android 2.2.2; ME860 Build/OLHKT_U4_0.50.0)|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (Linux; U; Android 2.1-update1; nl-be; U20i Build/2.1.1.A.0.6) AppleWebKit/525.10+ (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2 (AdMob-ANDROID-20091123)|http://wap.sonyericsson.com/UAprof/U20iR201.xml
+Dalvik/1.4.0 (Linux; U; Android 2.3.5; GT-I9100 Build/MIUI 1.8.5)|
+Dalvik/1.4.0 (Linux; U; Android 2.3.7; Hero Build/GRH78)|http://www.htcmms.com.tw/Android/TMO/Hero/ua-profile.xml
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[3309904256] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Opera/9.80 (Android; Opera Mini/5.1.22460/26.984; U; es) Presto/2.8.119 Version/10.54|
+NokiaE52-1/071.004; Series60/3.2 Profile/MIDP-2.1 Configuration/CLDC-1.1 3gpp-gba|http://nds1.nds.nokia.com/uaprof/NE52-1r100.xml
+BlackBerry9630/5.0.0.975 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/236|http://www.blackberry.net/go/mobile/profiles/uaprof/9630/4.7.1.rdf
+Mozilla/5.0 (Linux; U; Android 2.2.1; es-es; bq Voltaire Build/MASTER) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://gsm.lge.com/html/gsm/P990-M3-D2.xml
+Opera/9.80 (Android 2.3.5; Linux; Opera Mobi/ADR-1110071847; U; en-GB) Presto/2.9.201 Version/11.50|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_5 like Mac OS X; it_IT) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.5;FBSS/2; FBCR/VodafoneIT;FBID/phone;FBLC/it_IT;FBSF/2.0]|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.3;FBSS/2; FBCR/vodafoneUK;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.3.26549/26.984; U; es) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (iPod touch; U; CPU iPhone OS 4_1 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.1;FBBV/4010.0;FBDV/iPod4,1;FBMD/iPod touch;FBSN/iPhone OS;FBSV/4.1;FBSS/2; FBCR/;FBID/phone;FBLC/en_US;FBSF/2.0]|
+BlackBerry9000/5.0.0.862 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/297|http://www.blackberry.net/go/mobile/profiles/uaprof/9000/4.6.0.rdf
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.1.15231/26.984; U; tr) Presto/2.8.119 Version/10.54|
+Dalvik/1.4.0 (Linux; U; Android 2.3.5; HTC Sensation Z710e with Beats Audio Build/GRJ90)|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-gb; LG-P970/V10d Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 MMS/LG-Android-MMS-V1.0/1.2|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+NokiaE75-1/UC Browser7.9.0.102/28/355/UCWEB|http://nds1.nds.nokia.com/uaprof/NE75-1r100.xml
+Mozilla/5.0 (Linux; U; Android 2.2; fr-fr; ViewPad 10s Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (iPad; U; CPU iPhone OS 4_3_5 like Mac OS X; pt_BR) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPad2,2;FBMD/iPad;FBSN/iPhone OS;FBSV/4.3.5;FBSS/1; FBCR/AT|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone4,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/5.0;FBSS/2; FBCR/Bell;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Dalvik/1.2.0 (Linux; U; Android 2.2.1; Livall Build/MASTER)|http://gsm.lge.com/html/gsm/P990-M3-D2.xml
+Mozilla/5.0 (Linux; U; Android 1.6; es-es; SonyEricssonX10a Build/R2CA016) AppleWebKit/528.5  (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1|http://wap.sonyericsson.com/UAprof/X10aR101.xml
+Mozilla/5.0 (Linux; U; Android 2.1-update1; en-za; E10i Build/2.1.1.A.0.16) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17|http://wap.sonyericsson.com/UAprof/E10iR201.xml
+Mozilla/5.0 (Linux; U; Android 2.3; en-us; Nexus One Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (Linux; U; Android 2.3.4; de-de; SonyEricssonST17i Build/4.0.1.A.0.284) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Mozilla/5.0 (iPad; U; CPU iPhone OS 4_3_3 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPad2,1;FBMD/iPad;FBSN/iPhone OS;FBSV/4.3.3;FBSS/1; FBCR/;FBID/tablet;FBLC/en_US;FBSF/1.0]|
+Mozilla/5.0 (Linux; U; Android 2.2.2; fr-fr; LG-P350 Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; NOKIA; Lumia 800)|http://device.sprintpcs.com/HTC/SPS511BK/latest
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_2_1 like Mac OS X; de_DE) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone1,2;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.2.1;FBSS/1; FBCR/Telekom.de;FBID/phone;FBLC/de_DE;FBSF/1.0]|
+Dalvik/1.4.0 (Linux; U; Android 2.3.5; GT-S5830 Build/GINGERBREAD)|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.3;FBSS/2; FBCR/OrangeUK;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[7176681207] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (Linux; U; Android 2.1-update1; es-es; Nvsbl Build/ECLAIR) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17|http://wap1.huawei.com/uaprof/HuaweiU8230v100WCDMAEclair.xml
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.1.12965/26.984; U; en) Presto/2.8.119 Version/10.54|
+Dalvik/1.1.0 (Linux; U; Android 2.1-update1; Orange_Boston Build/ERE27)|http://wap1.huawei.com/uaprof/HuaweiU8230v100WCDMAEclair.xml
+Dalvik/1.2.0 (Linux; U; Android 2.2.1; GT-T959 Build/FROYO)|http://gsm.lge.com/html/gsm/P990-M3-D2.xml
+Mozilla/5.0 (Linux; U; Android 2.2.1; ar-qa; HTC Wildfire Build/FRG83D) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www.htcmms.com.tw/Android/Common/Buzz/ua-profile.xml
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.18975/26.984; U; id) Presto/2.8.119 Version/10.54|
+NokiaE66/UC Browser7.9.0.102/28/354/UCWEB|http://nds1.nds.nokia.com/uaprof/NE66-1r100.xml
+Dalvik/1.2.0 (Linux; U; Android 2.2.2; G2 Build/FRG83G)|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (iPod touch; U; CPU iPhone OS 5_0 like Mac OS X; it_IT) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPod4,1;FBMD/iPod touch;FBSN/iPhone OS;FBSV/5.0;FBSS/2; FBCR/;FBID/phone;FBLC/it_IT;FBSF/2.0]|
+Opera/9.80 (Android 3.1; Linux; Opera Tablet/ADR-1110071847; U; en-GB) Presto/2.9.201 Version/11.50|http://wap.samsungmobile.com/uaprof/GT-P7500.xml
+Mozilla/5.0 (Linux; U; Android 2.2.1; en-us; U8500 Build/HuaweiU8500) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://gsm.lge.com/html/gsm/P990-M3-D2.xml
+Mozilla/5.0 (Linux; U; Android 2.2.1; ar-eg; Milestone Build/SHOLS_U2_05.27.2) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://uaprof.motorola.com/phoneconfig/motoa853/Profile/motoa853.rdf
+Dalvik/1.2.0 (Linux; U; Android 2.2.2; U8520 Build/HuaweiU8520)|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+BlackBerry9000/5.0.0.771 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/121|http://www.blackberry.net/go/mobile/profiles/uaprof/9000/4.6.0.rdf
+BlackBerry9700/5.0.0.586 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/258|http://www.blackberry.net/go/mobile/profiles/uaprof/9700_umts/5.0.0.rdf
+Dalvik/1.4.0 (Linux; U; Android 2.3.7; Incredible S Build/GRI40)|
+Dalvik/1.4.0 (Linux; U; Android 2.3.4; ST17i Build/4.0.2.A.0.42)|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Opera/9.80 (S60; SymbOS; Opera Mobi/SYB-1107071606; U; hu) Presto/2.8.149 Version/11.10|
+Mozilla/5.0 (Linux; U; Android 2.3.3; en-au; LG-P500 Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 MMS/LG-Android-MMS-V1.0/1.2|
+Opera/9.80 (Android 2.1-update1; Linux; Opera Mobi/ADR-1110071847; U; pt) Presto/2.9.201 Version/11.50|http://wap1.huawei.com/uaprof/HuaweiU8230v100WCDMAEclair.xml
+Mozilla/5.0 (Linux; U; Android 2.2; en-us; Nexus One Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/5.0;FBSS/2; FBCR/Three;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Mozilla/5.0 (Linux; U; Android 2.3.4; ar-ae; GT-I9100G Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Mozilla/5.0 (iPad; U; CPU OS 4_3_3 like Mac OS X; he-il) AppleWebKit/533.17.9 (KHTML, like Gecko) Mobile/8J3|
+Opera/9.80 (J2ME/MIDP; Opera Mini/5.1.21051/26.984; U; ar) Presto/2.8.119 Version/10.54|
+nokiae61i-1/UC Browser7.7.1.88/69/444 UNTRUSTED/1.0|http://nds1.nds.nokia.com/uaprof/NE61i-1r100.xml
+Mozilla/5.0 (Linux; U; Android 2.3.5; en-za; GT-N7000 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (Linux; U; Android 2.2.2; fr-fr; ViewPad7 Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; ZTE-C N600+ Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (Linux; U; Android 2.3.3; en-vn; HTC_WildfireS_A510e Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www.htcmms.com.tw/Android/Common/PG76/ua-profile.xml
+Mozilla/5.0 (Linux; U; Android 2.3.5; ko-kr; SHW-M250K Build/MOG) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; ca-es) AppleWebKit/533.17.9 (KHTML, like Gecko) Mobile/8J2|
+Nokia1680c-2b_CMCC/2.0 (06.22) Profile/MIDP-2.1 Configuration/CLDC-1.1|http://nds1.nds.nokia.com/uaprof/N1680c-2r100.xml
+Dalvik/1.2.0 (Linux; U; Android 2.2.1; Vodafone 858 Build/Vodafone858C02B619)|http://gsm.lge.com/html/gsm/P990-M3-D2.xml
+SAMSUNG-E2210B/E2210BPEIJ1 UP.Browser/6.2.3.3.c.1.101 (GUI) MMP/2.0|
+Mozilla/5.0 (iPod touch; U; CPU iPhone OS 4_3_2 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.1;FBBV/4010.0;FBDV/iPod4,1;FBMD/iPod touch;FBSN/iPhone OS;FBSV/4.3.2;FBSS/2; FBCR/;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Dalvik/1.2.0 (Linux; U; Android 2.2; Eken M009s Build/Android 2.2 Froyo)|
+Dalvik/1.4.0 (Linux; U; Android 2.3; MID8024 Build/GINGERBREAD)|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.18149/26.984; U; ru) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Linux; U; Android 2.3.3; sv-se; Desire_A8181 Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www.htcmms.com.tw/Android/Common/PG88/ua-profile.xml
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3 like Mac OS X; en-gb) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8J2 Safari/6533.18.5|
+Dalvik/1.4.0 (Linux; U; Android 2.3.4; Racer Build/FRG83)|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+BlackBerry8520/5.0.0.1079 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/132|http://www.blackberry.net/go/mobile/profiles/uaprof/8520_80211g/4.6.1.rdf
+Mozilla/5.0 (Linux; U; Android 2.1-update1; en-au; HTC Liberty Build/ERE27) AppleWebKit/525.10+ (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2 (AdMob-ANDROID-20091123)|
+Mozilla/5.0 (Linux; U; Android 2.3.5; ko-; HUMBLE by Danalo1979 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.16320/26.984; U; it) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Linux; U; Android 2.3.4; ja-jp; DROID3 Build/5.5.1_84_D3G-55) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Mozilla/5.0 (Linux; U; Android 2.2.1; en-jp; S31HT Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://gsm.lge.com/html/gsm/P990-M3-D2.xml
+Mozilla/5.0 (Linux; U; Android 2.3.3; es-es; HTC ChaCha A810e Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+NOKIAE5-00/UC Browser7.9.0.102/28/355/UCWEB|http://nds1.nds.nokia.com/uaprof/NE5-00r100.xml
+Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0; FujitsuToshibaMobileCommun; IS12T; KDDI)|
+Dalvik/1.4.0 (Linux; U; Android 2.3.4; X10i Build/3.0.1.G.0.75)|http://wap.sonyericsson.com/UAprof/X10iR101.xml
+Dalvik/1.2.0 (Linux; U; Android 2.2.2; msm7227_ffa Build/I700T_P4_11A_FLXX_FT_R_0_01_1010_110527)|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Opera/9.80 (Android 2.3.7; Linux; Opera Tablet/ADR-1110071847; U; en) Presto/2.9.201 Version/11.50|
+SAMSUNG-S3600/S3600JVIF2 NetFront/3.4 Profile/MIDP-2.0 Configuration/CLDC-1.1|http://wap.samsungmobile.com/uaprof/S3600.xml
+Mozilla/5.0 (Linux; U; Android 2.3.4; zh-tw; HTC HD2 Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Dalvik/1.4.0 (Linux; U; Android 2.3.5; Liberty Build/GRI40)|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone4,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/5.0;FBSS/2; FBCR/AT|
+Opera/9.80 (Android 2.2; Linux; Opera Mobi/ADR-1110071847; U; en-GB) Presto/2.9.201 Version/11.50|
+Mozilla/5.0 (Linux; U; Android 2.3.4; de-de; HTC_Sensation_Z710e Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Dalvik/1.4.0 (Linux; U; Android 2.3.4; Thunderbolt Build/GRJ22)|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Dalvik/1.4.0 (Linux; U; Android 2.3.7; Evo Build/GRJ90)|
+Dalvik/1.1.0 (Linux; U; Android 2.1-update1-1.0.0; rk2818sdk Build/ECLAIR)|
+Mozilla/5.0 (Linux; U; Android 2.3.3; ja-jp; HTC_IncredibleS_S710e Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.21465/26.984; U; id) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; SCH-R730 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Blackberry 9700/5.0.0.1014 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/613|http://www.blackberry.net/go/mobile/profiles/uaprof/9700_umts/5.0.0.rdf
+Mozilla/5.0 (iPad; U; CPU iPhone OS 5_0 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPad1,1;FBMD/iPad;FBSN/iPhone OS;FBSV/5.0;FBSS/1; FBCR/;FBID/tablet;FBLC/en_US;FBSF/1.0]|
+KCI-S1350/ UP.Browser/7.2.7.2.593 (GUI) MMP/2.0|
+Dalvik/1.4.0 (Linux; U; Android 2.3.4; LG-P500 Build/GRJ22)|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Mozilla/5.0 (iPad; CPU OS 5_0 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Mobile/9A5313e Safari/ Sleipnir/1.4.6m|
+Dalvik/1.2.0 (Linux; U; Android 2.2.2; A953 Build/MILA2_U6_3.25.0)|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.3;FBSS/2; FBCR/bmobile;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Opera/9.80 (J2ME/MIDP; Opera Mini/5.22371/26.984; U; en) Presto/2.8.119 Version/10.5454|
+Opera/9.80 (J2ME/MIDP; Opera Mini/5.22371/26.984; U; es) Presto/2.8.119 Version/10.5454|
+SAMSUNG-SGH-A667/A667UCKH1; Mozilla/5.0 (Profile/MIDP-2.0 Configuration/CLDC-1.1; Opera Mini/att/4.2.20822; U; en-US) Opera 9.50|
+Dalvik/1.4.0 (Linux; U; Android 2.3.7; U20i Build/GingerDX Pro)|
+Opera/9.80 (J2ME/MIDP; Opera Mini/5.18487/26.984; U; es) Presto/2.8.119 Version/10.5454|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_2 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone2,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.2;FBSS/1; FBCR/AT&T;FBID/phone;FBLC/en_US;FBSF/1.0]|
+Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; SAMSUNG-SGH-I577 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (Linux; U; Android 2.3.5; de-de; MEDION LIFE P4310 Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Dalvik/1.2.0 (Linux; U; Android 2.2; GT-I5510T Build/FROYO)|
+Mozilla/5.0 (jAiLbr0ken; U; CPU iPhone OS 4_2_1 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8C148 Safari/6533.18.5|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_0_1 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.0.1;FBSS/2; FBCR/AT&T;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_0_1 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone2,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.0.1;FBSS/1; FBCR/Carrier;FBID/phone;FBLC/en_US;FBSF/1.0]|
+BlackBerry9000/5.0.0.314 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/214|http://www.blackberry.net/go/mobile/profiles/uaprof/9000/4.6.0.rdf
+Dalvik/1.2.0 (Linux; U; Android 2.2.1; GT-P1000N Build/FROYO)|http://wap.samsungmobile.com/uaprof/GT-P1000.xml
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[9375247748] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (Linux; U; Android 2.3.5; ko-kr; LG-LU6200 Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_2_1 like Mac OS X; de_DE) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.2.1;FBSS/2; FBCR/vfde;FBID/phone;FBLC/de_DE;FBSF/2.0]|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[3095400160] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Blackberry 9700/6.0.0.448 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/121|http://www.blackberry.net/go/mobile/profiles/uaprof/9700_umts/5.0.0.rdf
+Dalvik/1.4.0 (Linux; U; Android 2.3.5; GT-I9100 Build/GRJ22)|
+MQQBrowser/2.0 (NokiaN8-00;SymbianOS/9.1 Series60/3.0)|http://nds1.nds.nokia.com/uaprof/NN8-00r100-3G.xml
+SAMSUNG-GT-B3210/1.0 Release/10.19.2009 Browser/NetFront3.5 Profile/MIDP-2.0 Configuration/CLDC-1.1/*MzU4NjI4MDM0MTc1NDM2|http://wap.samsungmobile.com/uaprof/GT-B3210UAProf.xml
+BlackBerry9530/5.0.0.591 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/-1|http://www.blackberry.net/go/mobile/profiles/uaprof/9530_umts/4.7.0.rdf
+Dalvik/1.4.0 (Linux; U; Android 2.3.7; HTC Desire CDMA Build/GRI40)|http://uaprof.vtext.com/adr62k/adr62k.xml
+Dalvik/1.2.0 (Linux; U; Android 2.2; LG-LU3700 Build/FRF91)|
+Dalvik/1.4.0 (Linux; U; Android 2.3.5; DROID2 Build/VZW)|
+Blackberry 9700/6.0.0.666 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/107|http://www.blackberry.net/go/mobile/profiles/uaprof/9700_umts/5.0.0.rdf
+BlackBerry8520/5.0.0.1067 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/480|http://www.blackberry.net/go/mobile/profiles/uaprof/8520_80211g/4.6.1.rdf
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_1 like Mac OS X; ar_AR) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone2,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.1;FBSS/1; FBCR/Carrier;FBID/phone;FBLC/ar_AR;FBSF/1.0]|
+Mozilla/5.0 (BlackBerry; U; BlackBerry 9670; es) AppleWebKit/534.1  (KHTML, like Gecko) Version/6.0.0.248 Mobile Safari/534.1|
+Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; SAMSUNG-SGH-I777 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+BlackBerry9700/5.0.0.979 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/174|http://www.blackberry.net/go/mobile/profiles/uaprof/9700_umts/5.0.0.rdf
+Mozilla/5.0 (Linux; U; Android 2.1-update1; es-ec; SonyEricssonE10i-o Build/2.1.1.A.0.6) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17|http://wap.sonyericsson.com/UAprof/E10iR201.xml
+Dalvik/1.4.0 (Linux; U; Android 2.3.4; DROID2 Build/STAB)|
+Dalvik/1.4.0 (Linux; U; Android 2.3.3; DROID2 GLOBAL Build/4.5.1_57_D2G-38)|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone2,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/5.0;FBSS/1; FBCR/vodafoneUK;FBID/phone;FBLC/en_US;FBSF/1.0]|
+Dalvik/1.4.0 (Linux; U; Android 2.3.3; R800i Build/3.0.1.A.0.115)|
+Mozilla/5.0 (BlackBerry; U; BlackBerry 9900; en) AppleWebKit/534.11+ (KHTML, like Gecko) Version/7.0.0.424 Mobile Safari/534.11+|
+BlackBerry9000/4.6.0.247 Profile/MIDP-2.0 Configuration/CLDC-1.1 VendorID/299|http://www.blackberry.net/go/mobile/profiles/uaprof/9000/4.6.0.rdf
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[6084333669] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Dalvik/1.4.0 (Linux; U; Android 2.3.5; BASE Lutea 2 Build/GRJ22)|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[8135033539] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Opera/9.80 (J2ME/MIDP; Opera Mini/5.1.22296/26.984; U; es) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; de_DE) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.3;FBSS/2; FBCR/Carrier;FBID/phone;FBLC/de_DE;FBSF/2.0]|
+Mozilla/5.0 (Series40; NokiaC3-01/05.65; Profile/MIDP-2.1 Configuration/CLDC-1.1) Gecko/20100401 S40OviBrowser/1.0.2.26.6|http://nds1.nds.nokia.com/uaprof/NokiaC3-00r100.xml
+Mozilla/5.0 (Linux; U; Android 2.1-update1; fr-fr; U20i Build/2.0.2.A.0.24) AppleWebKit/525.10+ (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2 (AdMob-ANDROID-20091123)|http://wap.sonyericsson.com/UAprof/U20iR201.xml
+Mozilla/5.0 (Linux; U; Android 2.3.3; de-li; SonyEricssonLT15iv Build/4.0.A.2.368) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_5 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.5;FBSS/2; FBCR/Telstra;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Mozilla/5.0 (Linux; U; Android 2.2; en-us; CFW-MID7024 Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Opera/9.80 (iPhone; Opera Mini/6.13548/26.984; U; de) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_1 like Mac OS X; en_GB) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/3.5a;FBBV/3500;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.1;FBSS/2; FBCR/T-MobileUK;FBID/phone;FBLC/en_GB]|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; de_DE) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.3;FBSS/2; FBCR/Telekom.de;FBID/phone;FBLC/de_DE;FBSF/2.0]|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[3373773858] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (Linux; U; Android 2.3.5; pl-pl; MB525 Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://uaprof.motorola.com/phoneconfig/MotoMB525/profile/MotoMB525.rdf
+Blackberry 9800/6.0.0.570 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/600|http://www.blackberry.net/go/mobile/profiles/uaprof/9800_edge/6.0.0.rdf
+NokiaC6-01/UC Browser7.9.0.102/50/352/UCWEB|http://nds.nokia.com/uaprof/NC6-01r100.xml
+Dalvik/1.2.0 (Linux; U; Android 2.2; ZTE-BLADE Build/OPEN-MARKET-V1.0)|http://www.zte.com.cn/mobile/uaprof/ZTE-BLADE.xml
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[2604424184] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[6092542919] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Opera/9.80 (iPhone; Opera Mini/6.1.15738/26.984; U; en) Presto/2.8.119 Version/10.54.544|
+BlackBerry9700/5.0.0.593 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/310|http://www.blackberry.net/go/mobile/profiles/uaprof/9700_umts/5.0.0.rdf
+Opera/9.80 (Android 2.3.4; Linux; Opera Mobi/ADR-1110071847; U; fr) Presto/2.9.201 Version/11.50|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Dalvik/1.4.0 (Linux; U; Android 2.3.3; CLIQ XT Build/GRH78)|
+Mozilla/5.0 (Linux; U; Android 2.1-update1; fr-fr; X10i Build/2.1.A.0.435) AppleWebKit/525.10+ (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2 (AdMob-ANDROID-20091123)|http://wap.sonyericsson.com/UAprof/X10iR201.xml
+Opera/9.80 (S60; SymbOS; Opera Mobi/SYB-1106291583; U; lt) Presto/2.8.149 Version/11.10|
+Mozilla/5.0 (Linux; U; Android 2.1-update1; vi-vn; SonyEricssonU20a Build/2.1.1.A.0.6) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17|http://wap.sonyericsson.com/UAprof/U20aR201.xml
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.13918/26.984; U; en) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; LG-LW690 Build/GRJ90-LG-LW690) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[3362891895] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Dalvik/1.4.0 (Linux; U; Android 2.3.5; HTC Desire HD Build/MIUI-2.3.5b)|http://uaprof.vtext.com/adr62k/adr62k.xml
+SAMSUNG-SGH-A817/A817UCKH1; Mozilla/5.0 (Profile/MIDP-2.0 Configuration/CLDC-1.1; Opera Mini/att/4.2|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[5413311050] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_1 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8H7 Safari/6533.18.5|
+Mozilla/5.0 (Abdullah; U; CPU iPhone OS 4_2_1 like Mac OS X; de-de) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8C148 Safari/6533.18.5|
+Mozilla/5.0 (Linux; U; Android 2.2; fr-fr; E140 Build/Froyo) AppleWebKit/525.10+ (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2 (AdMob-ANDROID-20091123)|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[6142904496] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+LG-GT350/V100 Obigo/WAP2.0 Profile/MIDP-2.1 Configuration/CLDC-1.1 UNTRUSTED/1.0 lg-gt350/UC Browser7.9.0.102/69/352|http://gsm.lge.com/html/gsm/LG-GT350.xml
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_5 like Mac OS X; fr_FR) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.5;FBSS/2; FBCR/Rogers;FBID/phone;FBLC/fr_FR;FBSF/2.0]|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.20457/26.984; U; id) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-za; DroniX-0.5 Build/HuaweiU8180) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Nokia6500s-1/2.0 (09.40) Profile/MIDP-2.1 Configuration/CLDC-1.1 nokia6500s-1/UC Browser7.9.0.102/69/350 UNTRUSTED/1.0|http://nds1.nds.nokia.com/uaprof/N6500sr100.xml
+Mozilla/5.0 (Kool-Breeze; U; CPU iPhone OS 4_2_6 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8E200 Safari/6533.18.5|
+Apple-iPad1C1/901.334|
+Mozilla/5.0 (Linux; U; Android 2.1-update1; sv-se; ZTE-BLADE Build/ERE27) AppleWebKit/525.10+ (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2 (AdMob-ANDROID-20091123)|http://www.zte.com.cn/mobile/uaprof/ZTE-BLADE.xml
+Mozilla/5.0 (Linux; U; Android 2.3.7; en-us; MB860 Build/4.5.91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (iPod touch; U; CPU iPhone OS 4_2_1 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPod2,1;FBMD/iPod touch;FBSN/iPhone OS;FBSV/4.2.1;FBSS/1; FBCR/;FBID/phone;FBLC/en_US;FBSF/1.0]|
+Mozilla/5.0 (Linux; U; Android 2.2.2; ar-kw; u8800 Build/HuaweiU8800) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (Linux; U; Android 2.2; fr-be; Slidepad Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (Linux; U; Android 2.3.7; en-us; LG-P500 Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (Linux; U; Android 2.3.3; en-za; HTC HD2 Build/GRI54) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Dalvik/1.1.0 (Linux; U; Android 2.1-update1; MB511 Build/RUTLA_U3_00.53.0)|
+Mozilla/5.0 (iPad; U; CPU iPhone OS 4_3_1 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/3.5a;FBBV/3500;FBDV/iPad1,1;FBMD/iPad;FBSN/iPhone OS;FBSV/4.3.1;FBSS/1; FBCR/AT&T;FBID/phone;FBLC/en_US]|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3 like Mac OS X; de_DE) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3;FBSS/2; FBCR/o2-de;FBID/phone;FBLC/de_DE;FBSF/2.0]|
+Mozilla/5.0 (Linux; U; Android 2.3.7; es-es; HTC Desire Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://uaprof.vtext.com/adr62k/adr62k.xml
+Mozilla/5.0 (Linux; U; Android 2.2; es-es; MID1024 Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Opera/9.80 (Android 3.1; Linux; Opera Tablet/ADR-1110071847; U; de) Presto/2.9.201 Version/11.50|http://wap.samsungmobile.com/uaprof/GT-P7500.xml
+Dalvik/1.4.0 (Linux; U; Android 2.3.4; USCCADR6285US Build/GRJ22)|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Mozilla/5.0 (BlackBerry; U; BlackBerry 9800; en-US) AppleWebKit/534.8+ (KHTML, like Gecko) Version/6.0.0.561 Mobile Safari/534.8+|http://www.blackberry.net/go/mobile/profiles/uaprof/9800_edge/6.0.0.rdf
+Dalvik/1.5.1 (Linux; U; Android 3.1; streak7 Build/HMJ19)|http://wap.samsungmobile.com/uaprof/GT-P7500.xml
+Dalvik/1.2.0 (Linux; U; Android 2.2.1; Inspire HD Build/FRG83D)|http://gsm.lge.com/html/gsm/P990-M3-D2.xml
+Dalvik/1.4.0 (Linux; U; Android 2.3.5; HTC Desire Build/GRI40)|http://uaprof.vtext.com/adr62k/adr62k.xml
+Mozilla/5.0 (iPad; U; CPU iPhone OS 5_0 like Mac OS X; es_ES) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPad2,1;FBMD/iPad;FBSN/iPhone OS;FBSV/5.0;FBSS/1; FBCR/;FBID/tablet;FBLC/es_ES;FBSF/1.0]|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.23546/26.984; U; ar) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[9034753318] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_5 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.5;FBSS/2; FBCR/vodafoneUK;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Dalvik/1.2.0 (Linux; U; Android 2.2.2; ViewSonic-V350 Build/FRG83G)|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_5 like Mac OS X; ar_AR) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.5;FBSS/2; FBCR/Mobily;FBID/phone;FBLC/ar_AR;FBSF/2.0]|
+Blackberry 9780/6.0.0.570 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/123|http://www.blackberry.net/go/mobile/profiles/uaprof/9780/6.0.0.rdf
+Dalvik/1.4.0 (Linux; U; Android 2.3.5; HTC Desire Build/cMIUI 1.8.19 A2SD+)|http://uaprof.vtext.com/adr62k/adr62k.xml
+Mozilla/5.0 (Linux; U; Android 2.3.4; es-us; DROID BIONIC Build/5.5.1_84_DBN-55) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S5333/S5333JPJJ1; U; Bada/1.0; en-us) AppleWebKit/533.1 (KHTML, like Gecko) Dolfin/2.0 Mobile WQVGA SMM-MMS/1.2.0 OPN-B UNTRUSTED/1.0|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3;FBSS/2; FBCR/AT&T;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Opera/9.80 (J2ME/MIDP; Opera Mini/5.18264/26.984; U; ab) Presto/2.8.119 Version/10.54|
+BlackBerry9300/5.0.0.845 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/134|http://www.blackberry.net/go/mobile/profiles/uaprof/9300_umts/5.0.0.rdf
+Mozilla/5.0 (Linux; U; Android 2.3.4; fr-us; pcdadr6350 Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Opera/9.80 (BREW; Opera Mini/5.63/24.1029; U; en) Presto/2.5.25 240X320 Samsung SCH-U660|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.22714/26.984; U; id) Presto/2.8.119 Version/10.54|
+Dalvik/1.4.0 (Linux; U; Android 2.3.4; MB525 Build/4.5.1-134_DFP-10)|http://uaprof.motorola.com/phoneconfig/MotoMB525/profile/MotoMB525.rdf
+Dalvik/1.4.0 (Linux; U; Android 2.3.7; HTC Tattoo Build/GRI40)|http://www.htcmms.com.tw/Android/Common/Tattoo/ua-profile.xml
+Dalvik/1.2.0 (Linux; U; Android 2.2; SN10T1 Build/FRF91)|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.3;FBSS/2; FBCR/AT|
+NOKIAN73/UC Browser7.9.0.102/28/354/UCWEB|http://nds.nokia.com/uaprof/NN73-1r100.xml
+Opera/9.80 J2ME/MIDP; Opera Mini/4.1.15082/26.984; U; es Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/5.0;FBSS/2; FBCR/M1Singapore;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Mozilla/5.0 (iPad; U; CPU iPhone OS 5_0 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPad2,3;FBMD/iPad;FBSN/iPhone OS;FBSV/5.0;FBSS/1; FBCR/Verizon;FBID/tablet;FBLC/en_US;FBSF/1.0]|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; de_DE) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.1;FBBV/4010.0;FBDV/iPhone2,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.3;FBSS/1; FBCR/Telekom.de;FBID/phone;FBLC/de_DE;FBSF/1.0]|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.1.15082/26.984; U; id) Presto/2.8.119 Version/10.54|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.18975/26.984; U; es) Presto/2.8.119 Version/10.54|
+Opera/9.80 (BREW; Opera Mini/5.43/24.1029; U; en) Presto/2.5.25 320X240 LG VN250|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_5 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.5;FBSS/2; FBCR/3Ireland;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.1.15231/26.984; U; ar) Presto/2.8.119 Version/10.54|
+Dalvik/1.2.0 (Linux; U; Android 2.2; Vega Build/FRF91)|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3;FBSS/2; FBCR/etisalat;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14881/26.984; U; ar) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Vodafone/1.0/LG-GS290/V10g Browser/Obigo-Q7.3 MMS/LG-MMS-V1.0/1.2 MediaPlayer/LGPlayer/1.0 Java/ASVM/1.1 Profile/MIDP-2.1 Confication-Type: Browser|http://gsm.lge.com/html/gsm/LG-GS290-NS.xml
+Mozilla/5.0 (Linux; U; Android 1.6; en-fr; HTC Tattoo Build/DRC79) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1|http://www.htcmms.com.tw/Android/Common/Tattoo/ua-profile.xml
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone4,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/5.0;FBSS/2; FBCR/Sprint;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Mozilla/5.0 (Linux; U; Android 2.2.2; hu-hu; IDEOS S7 Slim Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (Linux; U; Android 2.3.5; es-es; GT-I9100 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.24725/26.984; U; tr) Presto/2.8.119 Version/10.54|
+Dalvik/1.4.0 (Linux; U; Android 2.3.4; Optimus 2X Build/MIUIAndroid 1.7.29)|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Dalvik/1.2.0 (Linux; U; Android 2.2.2; Karbonn_A1 Build/FRF91)|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Dalvik/1.4.0 (Linux; U; Android 2.3.4; OVO Community ROM Build/GRJ22)|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Dalvik/1.5.1 (Linux; U; Android 3.1; MZ604 Build/H.6.4-16)|http://wap.samsungmobile.com/uaprof/GT-P7500.xml
+Dalvik/1.2.0 (Linux; U; Android 2.2.2; i-mobile i691 Build/FRG83G)|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (iPad; U; CPU iPhone OS 4_3_3 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.1;FBBV/4010.0;FBDV/iPad2,2;FBMD/iPad;FBSN/iPhone OS;FBSV/4.3.3;FBSS/1; FBCR/AT&T;FBID/tablet;FBLC/en_US;FBSF/1.0]|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_2_1 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone2,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.2.1;FBSS/1; FBCR/AT|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.1.13685/26.984; U; en) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Linux; U; Android 2.1-update1; fr-fr; Garmin-Asus A10 Build/ERE27) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17; A10-V5.0.68-userdebug-20101020|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[2605826847] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (iPad; U; CPU iPhone OS 4_3_3 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.1;FBBV/4010.0;FBDV/iPad2,1;FBMD/iPad;FBSN/iPhone OS;FBSV/4.3.3;FBSS/1; FBCR/;FBID/tablet;FBLC/en_US;FBSF/1.0]|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_5 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.5;FBSS/2; FBCR/Bell;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Mozilla/5.0 (Linux; U; Android 3.1; es-es; AT100 Build/HMJ37) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13|http://wap.samsungmobile.com/uaprof/GT-P7500.xml
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/5.0;FBSS/2; FBCR/Rogers;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Opera/9.80 (Android; Opera Mini/5.1.22460/26.984; U; de) Presto/2.8.119 Version/10.54|
+MOT-V3/0E.40.9FR MIB/2.2.1 Profile/MIDP-2.0 Configuration/CLDC-1.0|http://motorola.handango.com/phoneconfig/v3/Profile/v3.rdf
+Dalvik/1.4.0 (Linux; U; Android 2.3.5; Nexus One Build/MIUI 1.10.8.0)|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.3;FBSS/2; FBCR/O2;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Dalvik/1.4.0 (Linux; U; Android 2.3.3; Dell Streak Build/GRI40)|
+Dalvik/1.2.0 (Linux; U; Android 2.2.2; IDEOS S7 Build/FRG83G)|
+Mozilla/5.0 (BlackBerry; U; BlackBerry 9370; en-US) AppleWebKit/534.11  (KHTML, like Gecko) Version/7.0.0.374 Mobile Safari/534.11|
+Dalvik/1.2.0 (Linux; U; Android 2.2; MID7024 Build/FRF91)|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_5 like Mac OS X; es_ES) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.5;FBSS/2; FBCR/Telcel;FBID/phone;FBLC/es_ES;FBSF/2.0]|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.18154/26.984; U; es) Presto/2.8.119 Version/10.54|
+Opera/9.80 (J2ME/MIDP; Opera Mini/5.20963/26.984; U; tr) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Linux; U; Android 2.3.3; ar-eg; HTC Incredible S Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Dalvik/1.4.0 (Linux; U; Android 2.3.5; HTC Desire Build/GINGERVillain-3.1)|http://uaprof.vtext.com/adr62k/adr62k.xml
+Mozilla/5.0 (Linux; U; Android 2.2.1; de-at; HTC Wildfire 2.31.163.1 Build/FRG83D) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www.htcmms.com.tw/Android/Common/Buzz/ua-profile.xml
+Mozilla/5.0 (Linux; U; Android 2.2.2; es-us; ViewPad7 Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[7656678665] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_5 like Mac OS X; de_DE) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.5;FBSS/2; FBCR/Vodafone.de;FBID/phone;FBLC/de_DE;FBSF/2.0]|
+BlackBerry9630/5.0.0.1078 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/126|http://www.blackberry.net/go/mobile/profiles/uaprof/9630/4.7.1.rdf
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.3.24214/26.984; U; tr) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[4328893691] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.17605/26.984; U; ar) Presto/2.8.119 Version/10.54|
+Dalvik/1.2.0 (Linux; U; Android 2.2.2 AcuraTeam www.htcspain.com; LG-P920 Build/FRG83G)|
+NokiaC1-01/2.0 (05.45) Profile/MIDP-2.1 Configuration/CLDC-1.1 nokiac1-01/UC Browser7.0.0.41/70/350 UNTRUSTED/1.0|
+Mozilla/5.0 (Linux; U; Android 2.3.5; ko-kr; SGH-T989 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/3.5a;FBBV/3500;FBDV/iPhone2,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.3;FBSS/1; FBCR/OPTUS;FBID/phone;FBLC/en_US]|
+Opera/9.80 (Android 3.2.1; Linux; Opera Tablet/ADR-1110071847; U; en-GB) Presto/2.9.201 Version/11.50|
+Mozilla/5.0 (Linux; U; Android 2.3.3; en-ie; SonyEricssonLT15i Build/3.0.1.A.0.151) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (Linux; U; Android 2.3.7; en-us; MB200 Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://uaprof.motorola.com/phoneconfig/MotoMB300/profile/MotoMB300.rdf
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/5.0;FBSS/2; FBCR/CarrierLab;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Mozilla/5.0 (iPod; CPU iPhone OS 5_0 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko)|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.21992/26.984; U; ar) Presto/2.8.119 Version/10.54|
+Opera/9.80 (BREW; Opera Mini/5.25/24.1029; U; en) Presto/2.5.25 320X240 Samsung SCH-U750|http://uaprof.vtext.com/sch/u750P/u750P.xml
+Dalvik/1.4.0 (Linux; U; Android 2.3.5; ZTE-BLADE Build/GRJ90)|http://www.zte.com.cn/mobile/uaprof/ZTE-BLADE.xml
+Opera/9.80 (MTK; Opera Mini/5.1.3086/26.984; U; en) Presto/2.8.119 Version/10.54|
+Dalvik/1.4.0 (Linux; U; Android RandomROM 2.3.4; SPH-D700 Build/GINGERBREAD)|http://device.sprintpcs.com/Samsung/SPH-D700/DI07.rdf
+Opera/9.80 (J2ME/MIDP; Opera Mini/5.16895/26.984; U; en) Presto/2.8.119 Version/10.54|
+Opera/9.80 (S60; SymbOS; Opera Mobi/SYB-1109211775; U; fa) Presto/2.8.149 Version/11.10|
+BlackBerry8520/5.0.0.1056 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/134|http://www.blackberry.net/go/mobile/profiles/uaprof/8520_80211g/4.6.1.rdf
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.1;FBBV/4010.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3;FBSS/2; FBCR/vodafoneIE;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Mozilla/5.0 (Linux; U; Android 2.3.3; en-gb; SonyEricssonLT15i Build/3.0.1.A.0.146) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Dalvik/1.2.0 (Linux; U; Android 2.2.2; ALCATEL one touch 890D Build/FRG83G)|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.20457/26.984; U; nl) Presto/2.8.119 Version/10.54|
+LG-GT405-Orange/V10e Browser/Teleca-Q7.1 MMS/LG-MMS-V1.0/1.2 MediaPlayer/LGPlayer/1.0 Java/ASVM/1.1 Profile/MIDP-2.1 Configuration/CLDC-1.1|http://gsm.lge.com/html/gsm/GT405-M6-D2.xml
+SAMSUNG-GT-S8530/S8530XXKE1 Bada/1.2 AppleWebKit/533.1 Dolfin/2.2 Mobile NexPlayer/3.0 SMM-MMS/1.2.0 profile/MIDP-2.1 configuration/CLDC-1.1 OPN-B|http://wap.samsungmobile.com/uaprof/GT-S8530_3G.rdf
+BlackBerry9630/4.2.0.424 Profile/MIDP-2.0 Configuration/CLDC-1.1|http://www.blackberry.net/go/mobile/profiles/uaprof/9630/4.7.1.rdf
+Mozilla/5.0 (BlackBerry; U; BlackBerry 9900; en) AppleWebKit/534.11+ (KHTML, like Gecko) Version/7.1.0.58 Mobile Safari/534.11+|
+Mozilla/5.0 (Linux; U; Android 2.3.3; en-us; DROID2 GLOBAL Build/4.5.1_57_D2G-38) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Opera/9.80 (J2ME/MIDP; Opera Mini/5.19390/26.984; U; es) Presto/2.8.119 Version/10.54|
+Opera/9.80 (J2ME/MIDP; Opera Mini/5.3521/26.984; U; en) Presto/2.8.119 Version/10.54|
+Opera/9.80 (J2ME/MIDP; Opera Mini/5.22282/26.984; U; en) Presto/2.8.119 Version/10.54|
+Nokia7610/2.0 (5.0509.0) SymbianOS/7.0s Series60/2.1 Profile/MIDP-2.0 Configuration/CLDC-1.0/UC Browser7.9.0.102/27/352/UCWEB|http://nds1.nds.nokia.com/uaprof/N7610r100.xml
+Mozilla/5.0 (BlackBerry; U; BlackBerry 9900; it) AppleWebKit/534.11+ (KHTML, like Gecko) Version/7.0.0.296 Mobile Safari/534.11+|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0 like Mac OS X; sv_SE) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/5.0;FBSS/2; FBCR/3SE;FBID/phone;FBLC/sv_SE;FBSF/2.0]|
+Mozilla/5.0 (Linux; U; Android 2.3.5; zh-cn; MB525 Build/MIUI) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://uaprof.motorola.com/phoneconfig/MotoMB525/profile/MotoMB525.rdf
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/5.0;FBSS/2; FBCR/Mobinil;FBID/phone;FBLC/en_US;FBSF/2.0]|
+LG-KE970/V11c Obigo/WAP2.0 MIDP-2.0/CLDC-1.1|http://gsm.lge.com/html/gsm/LG-KE970.xml
+Blackberry 9700/5.0.0.743 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/138|http://www.blackberry.net/go/mobile/profiles/uaprof/9700_umts/5.0.0.rdf
+Mozilla/5.0 (BlackBerry; U; BlackBerry 9900; en) AppleWebKit/534.11+ (KHTML, like Gecko) Version/7.0.0.440 Mobile Safari/534.11+|
+SAMSUNG-GT-S5260/S5260XXKG2 SHP/VPP/R5 Dolfin/2.0 NexPlayer/3.0 SMM-MMS/1.2.0 profile/MIDP-2.1 configuration/CLDC-1.1 OPN-B|http://wap.samsungmobile.com/uaprof/GT-S5260.rdf
+Mozilla/5.0 (Linux; U; Android 2.1-update1; ar-kw; HTC_Wildfire_A3333 Build/ERE27) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17|http://www.htcmms.com.tw/Android/Common/Wildfire/ua-profile.xml
+Dalvik/1.4.0 (Linux; U; Android 2.3.3; Android for Telechips M801 Evaluation Board Build/GRI40)|
+Dalvik/1.4.0 (Linux; U; Android 2.3.4; ST17i Build/4.0.1.A.0.284)|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Dalvik/1.4.0 (Linux; U; Android 2.3.5; GT-I9103 Build/GINGERBREAD)|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0 like Mac OS X; sv_SE) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone2,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/5.0;FBSS/1; FBCR/3SE;FBID/phone;FBLC/sv_SE;FBSF/1.0]|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.1.13907/25.893; U; ar) Presto/2.5.25 Version/10.54|
+Dalvik/1.4.0 (Linux; U; Android 2.3.5; ZTE Skate Build/V1.0.0B03)|
+NOKIAN76/UC Browser7.9.0.102/28/355/UCWEB|http://nds1.nds.nokia.com/uaprof/NN76-1r100.xml
+Opera/9.80 (Android 2.2; Linux; Opera Tablet/ADR-1110071847; U; en) Presto/2.9.201 Version/11.50|
+BlackBerry8520/5.0.0.979 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/118|http://www.blackberry.net/go/mobile/profiles/uaprof/8520_80211g/4.6.1.rdf
+Mozilla/5.0 (Linux; U; Android 2.3.3; ja-jp; INFOBAR A01 Build/S9081) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 3_1_2 like Mac OS X; tr-tr) AppleWebKit/528.18 (KHTML, like Gecko) Version/4.0 Mobile/Unknown Safari/528.16|
+Dalvik/1.4.0 (Linux; U; Android 2.3.7; HTC Desire Build/GINGERVillain-3.2)|http://uaprof.vtext.com/adr62k/adr62k.xml
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.22230/26.984; U; en) Presto/2.8.119 Version/10.54|
+Blackberry9300/6.0.0.448 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/604|http://www.blackberry.net/go/mobile/profiles/uaprof/9300_umts/5.0.0.rdf
+Mozilla/5.0 (Linux; U; Android 2.3.3; ar-kw; HTC_DesireHD_A9191 Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www.htcmms.com.tw/Android/Common/PG88/ua-profile.xml
+Dalvik/1.4.0 (Linux; U; Android 2.3.3; SO-01C Build/3.0.1.G.0.75)|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_2_1 like Mac OS X; de_DE) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.2.1;FBSS/2; FBCR/o2-de;FBID/phone;FBLC/de_DE;FBSF/2.0]|
+NokiaN72/5.0706.4.0.1 Series60/2.8 Profile/MIDP-2.0 Configuration/CLDC-1.1/UC Browser7.8.0.95/27/352|http://nds1.nds.nokia.com/uaprof/NN72r100.xml
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_2_5 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0;FBBV/4000.0;FBDV/iPhone3,3;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.2.5;FBSS/2; FBCR/Verizon;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_2_5 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0;FBBV/4000.0;FBDV/iPhone3,3;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.2.5;FBSS/2; FBCR/Verizon;FBID/phone;FBLC/en_US;FBSF/2.0]|
+BlackBerry9000/5.0.0.931 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/179|http://www.blackberry.net/go/mobile/profiles/uaprof/9000/4.6.0.rdf
+SAMSUNG-SGH-i900/AKHJ1 profile/MIDP-2.0 configuration/CLDC-1.1 Opera 9.5|http://wap.samsungmobile.com/uaprof/SGH-i900.xml
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_2_1 like Mac OS X; sv_SE) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.2.1;FBSS/2; FBCR/Telenor;FBID/phone;FBLC/sv_SE;FBSF/2.0]|
+Mozilla/5.0 (Linux; U; Android 2.2; ko-kr; SMA Build/11002700) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Dalvik/1.4.0 (Linux; U; Android 2.3.4; R800i Build/4.0.1.A.2.14)|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Mozilla/5.0 (Linux; U; Android 2.1-update1; pt-pt; Vodafone 845 Build/B226) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17|http://wap1.huawei.com/uaprof/HuaweiU8230v100WCDMAEclair.xml
+Mozilla/5.0 (BlackBerry; U; BlackBerry 9930; en-US) AppleWebKit/534.11+ (KHTML, like Gecko) Version/7.0.0.362 Mobile Safari/534.11+|
+Dalvik/1.2.0 (Linux; U; Android 2.2.2; LG-KU5900 Build/FRG83G)|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; G.net A6 Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Dalvik/1.4.0 (Linux; U; Android 2.3.3; HTC Legend Build/GRI40)|http://www.htcmms.com.tw/Android/Common/Legend/ua-profile.xml
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_5 like Mac OS X; de_DE) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.5;FBSS/2; FBCR/Carrier;FBID/phone;FBLC/de_DE;FBSF/2.0]|
+SAMSUNG-SGH-i900/AKIC1profile/MIDP-2.0 configuration/CLDC-1.1 Opera 9.5|http://wap.samsungmobile.com/uaprof/SGH-i900.xml
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.3;FBSS/2; FBCR/AT&T;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_1 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone2,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.1;FBSS/1; FBCR/vodafoneUK;FBID/phone;FBLC/en_US;FBSF/1.0]|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.8462/26.984; U; en) Presto/2.8.119 Version/10.54|
+Dalvik/1.4.0 (Linux; U; Android 2.3.4; SGH-T959V Build/GINGERBREAD)|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[0000006695] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Opera/9.80 (Android 2.3.1; Linux; Opera Tablet/ADR-1110071847; U; en) Presto/2.9.201 Version/11.50|http://wap.sonyericsson.com/UAprof/LT15iR301.xml
+Mozilla/5.0 (Linux; U; Android 2.3.3; ko-kr; LGC660 Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 MMS/LG-Android-MMS-V1.0/1.2|
+Blackberry 9800/6.0.0.546 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/609|http://www.blackberry.net/go/mobile/profiles/uaprof/9800_edge/6.0.0.rdf
+Mozilla/5.0 (Linux; U; Android 2.3.7; en-us; HTC Desire Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://uaprof.vtext.com/adr62k/adr62k.xml
+Dalvik/1.4.0 (Linux; U; Android 2.3.1; sdkDemo Build/GINGERBREAD)|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[6364393392] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Opera/9.80 (J2ME/MIDP; Opera Mini/5.17381/26.984; U; en) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/3.5a;FBBV/3500;FBDV/iPhone4,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/5.0;FBSS/2; FBCR/Verizon;FBID/phone;FBLC/en_US]|
+HTC_Touch_HD_T8282 Mozilla/4.0 (compatible; MSIE 4.01; Windows CE; PPC)/UC Browser7.6.1.82|http://www.htcmms.com.tw/gen/Blackstone-1.0.xml
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.17492/26.984; U; en) Presto/2.8.119 Version/10.54|
+Dalvik/1.4.0 (Linux; U; Android 2.3.5; M9 Build/GRJ90)|
+Opera/9.80 (J2ME/MIDP; Opera Mini/5.19693/26.984; U; es) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Linux; U; Android 2.2.1; es-es; LG-P500h Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 MMS/LG-Android-MMS-V1.0/1.2|http://gsm.lge.com/html/gsm/P990-M3-D2.xml
+Dalvik/1.4.0 (Linux; U; Android 2.3.5; Triumph Build/GRJ22)|
+Mozilla/5.0 (Linux; U; Android 2.2.2; zh-cn; LG-P990hN Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 MMS/LG-Android-MMS-V1.0/1.2|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Opera/9.80 (BlackBerry; Opera Mini/5.1.22303/26.984; U; en) Presto/2.8.119 Version/10.54|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.22537/26.984; U; ar) Presto/2.8.119 Version/10.54|
+Dalvik/1.1.0 (Linux; U; Android 2.1-update1; MB525 Build/JRDNEM_U3_2.51.2)|http://uaprof.motorola.com/phoneconfig/MotoMB525/profile/MotoMB525.rdf
+SAMSUNG-SGH-F480/F48RXFHI2 SHP/VPP/R5 NetFront/3.4 Qtv5.3 SMM-MMS/1.2.0 profile/MIDP-2.0 configuration/CLDC-1.1|http://wap.samsungmobile.com/uaprof/SGH-F480_3G.rdf
+Opera/9.80 (J2ME/MIDP; Opera Mini/5.18264/26.984; U; en) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Me so Horney :); U; CPU iPhone OS 4_2_1 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8C148 Safari/6533.18.5|
+Mozilla/5.0 (Linux; U; Android 2.2.2; de-de; ViewPad7 Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Dalvik/1.4.0 (Linux; U; Android 2.3.5; SCH-I405 Build/GINGERBREAD)|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[3029815674] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; HTC Inspire 4G Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; LG-P509 Build/FRG83G) AppleWebKit/525.10+ (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2 (AdMob-ANDROID-20091123)|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_0_1 like Mac OS X; en_GB) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/3.5a;FBBV/3500;FBDV/iPhone2,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.0.1;FBSS/1; FBCR/Carrier;FBID/phone;FBLC/en_GB]|
+Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; MK16a Build/4.0.1.A.0.283) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Mozilla/5.0 (Linux; U; Android 3.1; en-gb; GT-P7300 Build/HMJ37) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13|http://wap.samsungmobile.com/uaprof/GT-P7500.xml
+Opera/9.80 (J2ME/MIDP; Opera Mini/5.22234/26.984; U; en) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Linux; U; Android 2.2.1; en-us; MB525 Build/3.4.2-107_JDN-9) AppleWebKit/525.10+ (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2 (AdMob-ANDROID-20091123)|http://uaprof.motorola.com/phoneconfig/MotoMB525/profile/MotoMB525.rdf
+Mozilla/5.0 (Linux; U; Android 2.2.1; en-us; sapphire) AppleWebKit/525.10+ (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2|http://www.htcmms.com.tw/Android/TMO/Hero/ua-profile.xml
+Opera/9.80 (J2ME/MIDP; Opera Mini/5.1.24321/26.984; U; de) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Linux; U; Android 2.3.4; en-my; HTC_Sensation_Z710e Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Mozilla/5.0 (BlackBerry; U; BlackBerry 9800; es) AppleWebKit/534.8+ (KHTML, like Gecko) Version/6.0.0.666 Mobile Safari/534.8+|http://www.blackberry.net/go/mobile/profiles/uaprof/9800_edge/6.0.0.rdf
+BlackBerry8520/5.0.0.348 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/212|http://www.blackberry.net/go/mobile/profiles/uaprof/8520_80211g/4.6.1.rdf
+Opera/9.80 (J2ME/MIDP; Opera Mini/5.1.22296/26.984; U; ru) Presto/2.8.119 Version/10.54|
+Dalvik/1.4.0 (Linux; U; Android 2.3.5; HTC Desire Z Build/MIUI-1.9.30)|http://uaprof.vtext.com/adr62k/adr62k.xml
+Mozilla/5.0 (Linux; U; Android 2.3.5; de-de; SAMSUNG GT-I9100/I9100BUKI3F Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+NokiaE75-1/UC Browser7.9.0.102/28/352/UCWEB|http://nds1.nds.nokia.com/uaprof/NE75-1r100.xml
+Mozilla/5.0 (iPod touch; U; CPU iPhone OS 4_3_5 like Mac OS X; de_DE) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0;FBBV/4000.0;FBDV/iPod4,1;FBMD/iPod touch;FBSN/iPhone OS;FBSV/4.3.5;FBSS/2; FBCR/;FBID/phone;FBLC/de_DE;FBSF/2.0]|
+Mozilla/5.0 (SymbianOS/9.4; Series60/5.0 NokiaC6-00.1/20.2.041; Profile/MIDP-2.1 Configuration/CLDC-1.1) AppleWebKit/525 (KHTML, like Gecko) BrowserNG/7.2.6.9|
+Mozilla/5.0 (Linux; U; Android 2.1-update1; fr-fr; A101IT Build/ECLAIR)AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[5186817755] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_5 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0;FBBV/4000.0;FBDV/iPhone2,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.5;FBSS/1; FBCR/AT&T;FBID/phone;FBLC/en_US;FBSF/1.0]|
+Mozilla/5.0 (BlackBerry; U; BlackBerry 9900; en-GB) AppleWebKit/534.11+ (KHTML, like Gecko) Version/7.0.0.403 Mobile Safari/534.11+|
+Mozilla/5.0 (iPad; U; CPU OS 4_3 like Mac OS X; vi-vn) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8F190 Safari/6533.18.5|
+Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; T-Mobile G2 Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 BingWeb/2.0.546.20110811|http://www.htcmms.com.tw/Android/TMO/Hero/ua-profile.xml
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14912/26.984; U; de) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_5 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.5;FBSS/2; FBCR/OPTUS;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Mozilla/5.0 (Linux; U; Android 2.3.7; en-gb; HTC Desire Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://uaprof.vtext.com/adr62k/adr62k.xml
+Mozilla/5.0 (Linux; U; Android 2.3.5; fr-ca; Nexus One Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+BlackBerry8900/5.0.0.743 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/135|http://www.blackberry.net/go/mobile/profiles/uaprof/8900_80211g/4.6.1.rdf
+Opera/9.80 (S60; SymbOS; Opera Mobi/SYB-1109211775; U; es-ES) Presto/2.8.149 Version/11.10|
+Mozilla/5.0 (Linux; U; Android 2.2.1; fr-fr; HTC Wildfire Build/FRG83D) AppleWebKit/525.10+ (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2 (AdMob-ANDROID-20091123)|http://www.htcmms.com.tw/Android/Common/Buzz/ua-profile.xml
+Mozilla/5.0 (Linux; U; Android 2.2; en-us; Comet Build/FRF91) AppleWebKit/525.10+ (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2 (AdMob-ANDROID-20091123)|
+Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S8530/S8530XXJK2; U; Bada/1.2; pt-pt) AppleWebKit/533.1 (KHTML, like Gecko) Dolfin/2.2 Mobile WVGA SMM-MMS/1.2.0 OPN-B|http://wap.samsungmobile.com/uaprof/GT-S8530_3G.rdf
+Mozilla/5.0 (iPod touch; U; CPU iPhone OS 4_3_1 like Mac OS X; de_DE) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/3.5a;FBBV/3500;FBDV/iPod4,1;FBMD/iPod touch;FBSN/iPhone OS;FBSV/4.3.1;FBSS/2; FBCR/;FBID/phone;FBLC/de_DE]|
+Dalvik/1.4.0 (Linux; U; Android 2.3.5; GT-I9100 Build/MIUI 1.9.2)|
+Opera/9.80 (Android 2.2.2; Linux; Opera Mobi/ADR-1110071847; U; fr-CA) Presto/2.9.201 Version/11.50|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (iPad; U; CPU iPhone OS 4_2_1 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPad1,1;FBMD/iPad;FBSN/iPhone OS;FBSV/4.2.1;FBSS/1; FBCR/;FBID/tablet;FBLC/en_US;FBSF/1.0]|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_1 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0;FBBV/4000.0;FBDV/iPhone2,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.1;FBSS/1; FBCR/AT&T;FBID/phone;FBLC/en_US;FBSF/1.0]|
+Mozilla/5.0 (Linux; U; Android 2.2.2; de-de; SGH-T499Y Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (Linux; U; Android 2.3.3; es-es; GT-P1000N Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://wap.samsungmobile.com/uaprof/GT-P1000.xml
+Opera/9.80 (J2ME/MIDP; Opera Mini/5.21076/26.984; U; en) Presto/2.8.119 Version/10.54|
+Opera/9.80 (J2ME/MIDP; Opera Mini/5.1.21051/26.984; U; es) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; SCH-I110 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Opera/9.80 (Series 60; Opera Mini/5.1.22395/26.984; U; en) Presto/2.8.119 Version/10.54|
+SAMSUNG-GT-B3210/1.0 Release/10.19.2009 Browser/NetFront3.5 Profile/MIDP-2.0 Configuration/CLDC-1.1/*MzU4NjI4MDM0NDY5MzY3|http://wap.samsungmobile.com/uaprof/GT-B3210UAProf.xml
+BlackBerry8330/4.3.0 Profile/ MIDP-2.0 Configuration/ CLDC-1.1 VendorID/105|http://www.blackberry.net/go/mobile/profiles/uaprof/8330/4.3.0.rdf
+Mozilla/5.0 (Series40; NokiaC3-00/04.60; Profile/MIDP-2.1 Configuration/CLDC-1.1) Gecko/20100401 S40OviBrowser/1.4.0.34.8|http://nds1.nds.nokia.com/uaprof/NokiaC3-00r100.xml
+Mozilla/5.0 (Linux; U; Android 2.3.3; es-es; Android for Telechips M801 Evaluation Board Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.3.25172/26.984; U; ar) Presto/2.8.119 Version/10.54|
+Mozilla/4.0 (compatible; Nokia Podcasting; SymbianOS; NokiaN96-1/3.00;)|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[3303477870] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Nokia7610/2.0 (7.0642.0) SymbianOS/7.0s Series60/2.1 Profile/MIDP-2.0 Configuration/CLDC-1.0/UC Browser7.9.0.102/27/354/UCWEB|http://nds1.nds.nokia.com/uaprof/N7610r100.xml
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[4175699908] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Opera/9.80 (BlackBerry; Opera Mini/5.1.22265/26.984; U; en) Presto/2.8.119 Version/10.54|
+Opera/9.80 (iPhone; Opera Mini/6.1.15738/26.984; U; tr) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Symbian/3; Series60/5.3 NokiaE7-00/111.020.0307; Profile/MIDP-2.1 Configuration/CLDC-1.1 ) AppleWebKit/533.4 (KHTML, like Gecko) NokiaBrowser/7.4.1.14 Mobile Safari/533.4 3gpp-gba|http://nds1.nds.nokia.com/uaprof/NE7-00r100.xml
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.17605/26.984; U; es) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Linux; U; Android 2.2.1; en-ca; X10i Build/FreeX10-beta3_zdzihu) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://wap.sonyericsson.com/UAprof/X10iR101.xml
+Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; MB526 Build/4.5.1-134_DFP-38) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Opera/9.80 (Series 60; Opera Mini/5.1.22784/26.984; U; ar) Presto/2.8.119 Version/10.54|
+Dalvik/1.4.0 (Linux; U; Android 2.3.7; u8160 Build/GINGERBREAD)|
+Dalvik/1.4.0 (Linux; U; Android 2.3.7; Z71 Build/GRJ22)|
+Opera/9.80 (Android 2.1-update1; Linux; Opera Mobi/ADR-1110071847; U; fr) Presto/2.9.201 Version/11.50|http://wap1.huawei.com/uaprof/HuaweiU8230v100WCDMAEclair.xml
+Nokia6080/2.0 (03.33) Profile/MIDP-2.0 Configuration/CLDC-1.1|http://nds.nokia.com/uaprof/N6080r100.xml
+Opera/9.80 (iPhone; Opera Mini/5.19802/26.984; U; en) Presto/2.8.119 Version/10.54|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.10247/26.984; U; id) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[6144206722] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.22228/26.984; U; es) Presto/2.8.119 Version/10.54|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.19634/26.984; U; en) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Linux; U; Android Eclair; fr-fr Build/ECLAIR) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/5.0;FBSS/2; FBCR/OrangeUK;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_2_5 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,3;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.2.5;FBSS/2; FBCR/Verizon;FBID/phone;FBLC/en_US;FBSF/2.0]|
+BlackBerry8520/4.6.1.314 Profile/MIDP-2.0 Configuration/CLDC-1.1 VendorID/614|http://www.blackberry.net/go/mobile/profiles/uaprof/8520_80211g/4.6.1.rdf
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14613/26.984; U; en) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Linux; U; Android 2.3.5; en-gb; San Francisco II Build/OUK_B02) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Dalvik/1.4.0 (Linux; U; Android 2.3.4; Legend Build/GRH55)|http://www.htcmms.com.tw/Android/Common/Legend/ua-profile.xml
+Dalvik/1.5.1 (Linux; U; Android 3.1; Optimus 2x Build/HMJ37)|http://wap.samsungmobile.com/uaprof/GT-P7500.xml
+Opera/9.80 (J2ME/MIDP; Opera Mini/5.19376/26.984; U; en) Presto/2.8.119 Version/10.54|
+Opera/9.80 (Android 2.3.4; Linux; Opera Mobi/ADR-1109081720; U; fr-CA) Presto/2.8.149 Version/11.10|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_2_8 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,3;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.2.8;FBSS/2; FBCR/Verizon;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Mozilla/5.0 (Linux; U; Android 2.1-update1; en-sa; Desire_A8181 Build/ERE27) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17|http://www.htcmms.com.tw/Android/Common/Bravo/HTC_Desire_A8181.xml
+Mozilla/5.0 (Linux; U; Android 2.3.7; en-us; Nexus One Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Huawei U9120/196 Browser/NetFront/3.5 Profile/MIDP-2.0 Configuration/CLDC-1.1|
+Dalvik/1.2.0 (Linux; U; Android 2.2.2; ZTE-U X850 Build/FRF91)|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (SymbianOS/9.3; Series60/3.2 NokiaE52-1/052.003; Profile/MIDP-2.1 Configuration/CLDC-1.1 ) AppleWebKit/525 (KHTML, like Gecko) Version/3.0 BrowserNG/7.2.6.2|http://nds1.nds.nokia.com/uaprof/NE52-1r100.xml
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/5.0;FBSS/2; FBCR/Carrier;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Mozilla/5.0 (Linux; U; Android 2.3.3; zh-cn; R800x Build/3.0.1.E.0.88) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (iPad; U; CPU iPhone OS 5_0 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPad2,2;FBMD/iPad;FBSN/iPhone OS;FBSV/5.0;FBSS/1; FBCR/;FBID/tablet;FBLC/en_US;FBSF/1.0]|
+Mozilla/5.0 (iPad; U; CPU iPhone OS 4_3_5 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPad2,2;FBMD/iPad;FBSN/iPhone OS;FBSV/4.3.5;FBSS/1; FBCR/Three;FBID/tablet;FBLC/en_US;FBSF/1.0]|
+Mozilla/5.0 (BlackBerry; U; BlackBerry 9700; es) AppleWebKit/534.8+ (KHTML, like Gecko) Version/6.0.0.668 Mobile Safari/534.8+|http://www.blackberry.net/go/mobile/profiles/uaprof/9700_umts/6.0.0.rdf
+Dalvik/1.4.0 (Linux; U; Android 2.3.5; ADR6300 Build/FRF91)|
+Nokia5200/2.0 (07.20) Profile/MIDP-2.0 Configuration/CLDC-1.1 nokia5200/UC Browser7.9.0.102/69/352 UNTRUSTED/1.0|http://nds1.nds.nokia.com/uaprof/N5200r100.xml
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.16402/26.984; U; en) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Linux; U; Android 2.2.2; ru-ru; HTC Desire HD Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://uaprof.vtext.com/adr62k/adr62k.xml
+Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; SCH-I405 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.20464/26.984; U; es) Presto/2.8.119 Version/10.54|
+Dalvik/1.4.0 (Linux; U; Android 2.3.5; T3 Build/GRJ22)|
+Dalvik/1.4.0 (Linux; U; Android 2.3.4; X8 Build/GRJ22)|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Opera/9.80 (iPhone; Opera Mini/5.176/26.984; U; en) Presto/2.8.119 Version/10.54|
+Opera/9.80 (iPhone; Opera Mini/5.176/26.984; U; en) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SCH-M828C[9186137710] Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www-ccpp.tcl-ta.com/files/ALCATEL_one_touch_908.xml
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/5.0;FBSS/2; FBCR/AT|
+Mozilla/5.0 (Linux; U; Android 2.2; en_us; LG-P500h Build/FROYO) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 NetFrontLifeBrowser/2.2 Mobile (Dragonfruit)|
+Mozilla/5.0 (Linux; U; Android 2.2.1; en-us) AppleWebKit/534.12 (KHTML, like Gecko) Puffin/1.3.3126S Mobile Safari/534.12|http://gsm.lge.com/html/gsm/P990-M3-D2.xml
+Opera/9.80 (Series 60; Opera Mini/5.1.22395/26.984; U; ar) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/5.0;FBSS/2; FBCR/fido;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/5.0;FBSS/2; FBCR/vodafoneUK;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.14004/26.984; U; en) Presto/2.8.119 Version/10.54|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.13567/26.984; U; en) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Linux; U; Android 2.3.3; en-sa; HTC_ChaCha_A810e Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Mozilla/5.0 (Linux; U; Android 2.3.3; en-us; HTC Sapphire Build/unknown) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www.htcmms.com.tw/Android/TMO/Hero/ua-profile.xml
+Mozilla/5.0 (Linux; U; Android 2.3.3; pl-pl; HTC Wildfire S A510e Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://www.htcmms.com.tw/Android/Common/PG76/ua-profile.xml
+Dalvik/1.4.0 (Linux; U; Android 2.3.7; U20i Build/GRJ22)|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.1.13572/26.984; U; fr) Presto/2.8.119 Version/10.54|
+Dalvik/1.4.0 (Linux; U; Android 2.3.4; SHW-M180K Build/GINGERBREAD)|http://www.htcmms.com.tw/Android/Common/PG863/ua-profile.xml
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.18154/26.984; U; fr) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (Linux; U; Android 2.3.5; zh-tw; MB525 Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|http://uaprof.motorola.com/phoneconfig/MotoMB525/profile/MotoMB525.rdf
+Opera/9.80 (Android 2.3.3; Linux; Opera Mobi/ADR-1110071847; U; sv) Presto/2.9.201 Version/11.50|
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.3;FBSS/2; FBCR/Carrier;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Mozilla/5.0 (Linux; U; Android 2.2; zh-hk; PC36100 Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1|
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.24721/26.984; U; en) Presto/2.8.119 Version/10.54|
+Dalvik/1.4.0 (Linux; U; Android 2.3.3; SBM006SH Build/S0012)|
+NOKIAN95/UC Browser7.9.0.102/28/354/UCWEB|http://nds1.nds.nokia.com/uaprof/NN95-1r100.xml
+Blackberry9700/5.0.0.862 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/145|http://www.blackberry.net/go/mobile/profiles/uaprof/9700_umts/5.0.0.rdf
+Opera/9.80 (J2ME/MIDP; Opera Mini/4.2.23453/26.984; U; ar) Presto/2.8.119 Version/10.54|
+Mozilla/5.0 (BlackBerry; U; BlackBerry 9300; en-GB) AppleWebKit/534.8+ (KHTML, like Gecko) Version/6.0.0.650 Mobile Safari/534.8+|http://www.blackberry.net/go/mobile/profiles/uaprof/9300_umts/6.0.0.rdf
+SAMSUNG-SGH-i900Orange/RTIC1 (compatible; MSIE 6.0; Windows CE; IEMobile 7.11)|http://wap.samsungmobile.com/uaprof/SGH-i900.xml
+Mozilla/5.0 (Linux; U; Android 2.2; en-gb; HTC_DesireHD-orange-LS Build/FRF91)|http://www.htcmms.com.tw/Android/Common/Bravo/HTC_Desire_A8181.xml
+Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_5 like Mac OS X; en_US) AppleWebKit (KHTML, like Gecko) Mobile [FBAN/FBForIPhone;FBAV/4.0.2;FBBV/4020.0;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/4.3.5;FBSS/2; FBCR/OrangeUK;FBID/phone;FBLC/en_US;FBSF/2.0]|
+Mozilla/5.0 (Linux; U; Android 2.1-update1; cs-cz; SonyEricssonX10i Build/2.1.B.0.1) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17|http://wap.sonyericsson.com/UAprof/X10iR201.xml
+NokiaC2-00/2.0 (03.42) Profile/MIDP-2.1 Configuration/CLDC-1.1|


### PR DESCRIPTION
Simplify detection procedure by removing benchmark_span.
Removed PHP 7 from travis tests, then added it back (PHP 7 is now out).
Fix broken examples.php.