### PR TITLE
Bugfixes & Optimizations

### DIFF
--- a/src/HD4.php
+++ b/src/HD4.php
@@ -280,7 +280,8 @@ class HD4 extends HDBase {
 	 */		
 	function deviceDetect($data=null) {
 		$id = (int) (empty($data['id']) ? $this->config['site_id'] : $data['id']);
-		$requestBody = array_merge($this->detectRequest, (array) $data);
+		unset($data['id']);
+		$requestBody = ! empty($data) ? $data : $this->detectRequest;
 		$fastKey = '';
 		
 		// If caching enabled then check cache

--- a/src/HDDevice.php
+++ b/src/HDDevice.php
@@ -588,6 +588,8 @@ class HDDevice extends HDBase {
 
 		// Sanitize headers & cleanup language
 		foreach($headers as $key => $value) {
+			$key = strtolower($key);
+
 			if ($key == 'accept-language' || $key == 'content-language') {
 				$key = 'language';
 				$tmp = preg_split("/[,;]/", str_replace(" ","", strtolower($value)));
@@ -595,9 +597,17 @@ class HDDevice extends HDBase {
 					$value = $tmp[0];
 				else
 					continue;
+			} elseif ($key != 'profile' && $key != 'x-wap-profile') {
+				// Handle strings that have had + substituted for a space ie. badly (semi) url encoded..
+				$charCounts = count_chars($value, 0);
+				$stringLen = strlen($value);
+				if ($charCounts[ord(' ')] == 0 && $charCounts[ord('+')] > 5 && $stringLen > 20) {
+					$value = str_replace('+', ' ', $value);
+				}
 			}
-			$this->deviceHeaders[strtolower($key)] = $this->cleanStr($value);
-			$this->extraHeaders[strtolower($key)] = $this->Extra->extraCleanStr($value);
+
+			$this->deviceHeaders[$key] = $this->cleanStr($value);
+			$this->extraHeaders[$key] = $this->Extra->extraCleanStr($value);
 		}
 
 		$this->device = $this->matchDevice($this->deviceHeaders);

--- a/src/HDStore.php
+++ b/src/HDStore.php
@@ -44,13 +44,10 @@ class HDStore {
 	private $config = array();
 	
 	/**
-	 * Singleton Constructor
+	 * Constructor
 	 *
-	 * @param string $path Location of storage ROOT dir.
-	 * @param boolean $createDirectory - Create storage directory if it does not exist
 	 **/
-	private function __construct($config = array()) {
-		$this->setConfig($config, true);
+	private function __construct() {
 	}
 
 	/**

--- a/tests/hdStoreTest.php
+++ b/tests/hdStoreTest.php
@@ -15,6 +15,7 @@ class HDStoreTest extends PHPUnit_Framework_TestCase {
 	function testReadWrite() {
 		$key = 'storekey'.time();
 		$store = HandsetDetection\HDStore::getInstance();
+		$store->setConfig(array('filesdir' => '/tmp'), true);
 		$store->write($key, $this->testData);
 
 		$data = $store->read($key);
@@ -32,6 +33,7 @@ class HDStoreTest extends PHPUnit_Framework_TestCase {
 	function testStoreFetch() {
 		$key = 'storekey2'.time();
 		$store = HandsetDetection\HDStore::getInstance();
+		$store->setConfig(array('filesdir' => '/tmp'), true);
 		$store->store($key, $this->testData);
 
 		$cache = new HandsetDetection\HDCache();
@@ -48,6 +50,7 @@ class HDStoreTest extends PHPUnit_Framework_TestCase {
 	// Test purge
 	function testPurge() {
 		$store = HandsetDetection\HDStore::getInstance();
+		$store->setConfig(array('filesdir' => '/tmp'), true);
 		$files = glob($store->directory . DIRECTORY_SEPARATOR . '*.json');
 		$this->assertNotEmpty($files);
 		
@@ -61,6 +64,7 @@ class HDStoreTest extends PHPUnit_Framework_TestCase {
 	function testFetchDevices() {
 		$key = 'Device'.time();
 		$store = HandsetDetection\HDStore::getInstance();
+		$store->setConfig(array('filesdir' => '/tmp'), true);
 		$store->store($key, $this->testData);
 
 		$devices = $store->fetchDevices();
@@ -71,6 +75,7 @@ class HDStoreTest extends PHPUnit_Framework_TestCase {
 	// Moves a file from disk into store (vanishes from previous location).
 	function testMoveInFetch() {
 		$store = HandsetDetection\HDStore::getInstance();
+		$store->setConfig(array('filesdir' => '/tmp'), true);
 		$store->purge();
 
 		$tmpData = '{"Device":{"_id":"3454","hd_ops":{"is_generic":0,"stop_on_detect":0,"overlay_result_specs":0},"hd_specs":{"general_vendor":"Sagem","general_model":"MyX5-2","general_platform":"","general_image":"","general_aliases":"","general_eusar":"","general_battery":"","general_type":"","general_cpu":"","design_formfactor":"","design_dimensions":"","design_weight":0,"design_antenna":"","design_keyboard":"","design_softkeys":"","design_sidekeys":"","display_type":"","display_color":"","display_colors":"","display_size":"","display_x":"128","display_y":"160","display_other":"","memory_internal":"","memory_slot":"","network":"","media_camera":"","media_secondcamera":"","media_videocapture":"","media_videoplayback":"","media_audio":"","media_other":"","features":"","connectors":"","general_platform_version":"","general_browser":"","general_browser_version":"","general_language":"","general_platform_version_max":"","general_app":"","general_app_version":"","display_ppi":0,"display_pixel_ratio":0,"benchmark_min":0,"benchmark_max":0,"general_app_category":"","general_virtual":0,"display_css_screen_sizes":""}}}';
@@ -96,6 +101,7 @@ class HDStoreTest extends PHPUnit_Framework_TestCase {
 	// Test singleton'ship
 	function testSingleton() {
 		$store = HandsetDetection\HDStore::getInstance();
+		$store->setConfig(array('filesdir' => '/tmp'), true);
 		$store2 = HandsetDetection\HDStore::getInstance();
 
 		$store->setConfig(array('filesdir' => '/tmp/storetest'));


### PR DESCRIPTION
Ticket 13452 : HD4.deviceDetection should use passed data instead of merging passed data with existing data - Fixed.
Ticket 13450 : HDStore constructor creates empty directory in CWD - Fixed.
Ticket 13249 : Headers with plus (+) replacing space ( ) not detecting correctly - Fixed.