### PR TITLE
BugFix Ticket 13641

### DIFF
--- a/src/HDBase.php
+++ b/src/HDBase.php
@@ -66,14 +66,18 @@ class HDBase {
 							),
 		'platform-bi-order' => array(
 								'android' => array(
-									array('ro.build.id', 'ro.build.version.release'),
-									array('ro-build-id', 'ro-build-version-release'),
+									array('hd-platform', 'ro.build.version.release'),
+									array('hd-platform', 'ro-build-version-release'),
+									array('hd-platform', 'ro.build.id'),
+									array('hd-platform', 'ro-build-id')
 								),
 								'ios' => array(
-									array('uidevice.systemname','uidevice.systemversion')
+									array('uidevice.systemname','uidevice.systemversion'),
+									array('hd-platform','uidevice.systemversion')
 								),
 								'windows phone' => array(
-									array('osname','osversion')
+									array('osname','osversion'),
+									array('hd-platform','osversion')
 								)
 							),
 		'browser-bi-order' => array(),

--- a/src/HDDevice.php
+++ b/src/HDDevice.php
@@ -287,9 +287,12 @@ class HDDevice extends HDBase {
 	function specsOverlay($specsField, &$device, $specs) {
 		switch ($specsField) {
 			case 'platform' : {
-				if (! empty($specs['hd_specs']['general_platform'])) {
+				if (! empty($specs['hd_specs']['general_platform']) && ! empty($specs['hd_specs']['general_platform_version'])) {
 					$device['Device']['hd_specs']['general_platform'] = $specs['hd_specs']['general_platform'];
 					$device['Device']['hd_specs']['general_platform_version'] = $specs['hd_specs']['general_platform_version'];
+				} elseif (! empty($specs['hd_specs']['general_platform']) && $specs['hd_specs']['general_platform'] != $device['Device']['hd_specs']['general_platform']) {
+					$device['Device']['hd_specs']['general_platform'] = $specs['hd_specs']['general_platform'];
+					$device['Device']['hd_specs']['general_platform_version'] = '';
 				}
 			} break;
 
@@ -521,11 +524,13 @@ class HDDevice extends HDBase {
 
 		$hints = array();
 		foreach($confBIKeys as $platform => $set) {
-			$value = '';
 			foreach($set as $tuple) {
 				$checking = true;
+				$value = '';
 				foreach($tuple as $item) {
-					if (! isset($buildInfo[$item])) {
+					if ($item == 'hd-platform') {
+						$value .= '|'.$platform;
+					} elseif (! isset($buildInfo[$item])) {
 						$checking = false;
 						break;
 					} else {

--- a/tests/hd4Test.php
+++ b/tests/hd4Test.php
@@ -465,7 +465,56 @@ class HD4Test extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('Samsung', $reply['hd_specs']['general_vendor']);
 		$this->assertEquals('GT-I9500', $reply['hd_specs']['general_model']);
 		$this->assertEquals('Android', $reply['hd_specs']['general_platform']);
-		//$this->assertEquals('4.4.2', $reply['hd_specs']['general_platform_version']);
+		$this->assertEquals('4.4.2', $reply['hd_specs']['general_platform_version']);
+		$this->assertEquals('Samsung Galaxy S4', $reply['hd_specs']['general_aliases'][0]);
+		$this->assertEquals('Mobile', $reply['hd_specs']['general_type']);
+	}
+
+	/**
+	 * Detection test Samsung GT-I9500 Native - Note : Device shipped with Android 4.2.2, so this device has been updated.
+	 * @depends test_cloudConfigExists
+	 * @group cloud
+	 **/
+	function test_deviceDetectBIAndroidUpdatedOs() {
+		$buildInfo = array (
+			'ro.build.id' => 'KOT49H',
+			'ro.build.version.release' => '5.2',
+			'ro.build.version.sdk' => '19',
+			'ro.product.brand' => 'samsung',
+			'ro.product.model' => 'GT-I9500',
+		);
+
+		$hd = new HandsetDetection\HD4($this->cloudConfig);
+		$result = $hd->deviceDetect($buildInfo);
+		$reply = $hd->getReply();
+
+		$this->assertEquals('Samsung', $reply['hd_specs']['general_vendor']);
+		$this->assertEquals('GT-I9500', $reply['hd_specs']['general_model']);
+		$this->assertEquals('Android', $reply['hd_specs']['general_platform']);
+		$this->assertEquals('5.2', $reply['hd_specs']['general_platform_version']);
+		$this->assertEquals('Samsung Galaxy S4', $reply['hd_specs']['general_aliases'][0]);
+		$this->assertEquals('Mobile', $reply['hd_specs']['general_type']);
+	}
+
+	/**
+	 * Detection test Samsung GT-I9500 Native - Note : Device shipped with Android 4.2.2, so this device has been updated.
+	 * @depends test_cloudConfigExists
+	 * @group cloud
+	 **/
+	function test_deviceDetectBIAndroidDefaultOs() {
+		$buildInfo = array (
+			'ro.product.brand' => 'samsung',
+			'ro.product.model' => 'GT-I9500',
+		);
+
+		$hd = new HandsetDetection\HD4($this->cloudConfig);
+		$result = $hd->deviceDetect($buildInfo);
+		$reply = $hd->getReply();
+
+		$this->assertEquals('Samsung', $reply['hd_specs']['general_vendor']);
+		$this->assertEquals('GT-I9500', $reply['hd_specs']['general_model']);
+		$this->assertEquals('Android', $reply['hd_specs']['general_platform']);
+		$this->assertEquals('4.2.2', $reply['hd_specs']['general_platform_version']);
 		$this->assertEquals('Samsung Galaxy S4', $reply['hd_specs']['general_aliases'][0]);
 		$this->assertEquals('Mobile', $reply['hd_specs']['general_type']);
 	}
@@ -486,7 +535,7 @@ class HD4Test extends PHPUnit_Framework_TestCase {
 		$reply = $hd->getReply();
 
 		//print_r(json_encode($reply));
-		
+
 		$this->assertEquals('Apple', $reply['hd_specs']['general_vendor']);
 		$this->assertEquals('iPhone 4S', $reply['hd_specs']['general_model']);
 		$this->assertEquals('iOS', $reply['hd_specs']['general_platform']);
@@ -494,7 +543,34 @@ class HD4Test extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('5.0', $reply['hd_specs']['general_platform_version']);
 		$this->assertEquals('Mobile', $reply['hd_specs']['general_type']);
 	}
-	
+
+	/**
+	 * Detection test iPhone 4S Native
+	 * @depends test_cloudConfigExists
+	 * @group cloud
+	 **/
+	function test_deviceDetectBIiOSUpdatedOs() {
+		$buildInfo = array (
+			'utsname.machine' => 'iphone4,1',
+			'utsname.brand' => 'Apple',
+			'uidevice.systemVersion' => '5.1',
+			'UIDEVICE.SYSTEMNAME' => 'iphone os' 
+		);
+
+		$hd = new HandsetDetection\HD4($this->cloudConfig);
+		$result = $hd->deviceDetect($buildInfo);
+		$reply = $hd->getReply();
+
+		//print_r(json_encode($reply));
+		
+		$this->assertEquals('Apple', $reply['hd_specs']['general_vendor']);
+		$this->assertEquals('iPhone 4S', $reply['hd_specs']['general_model']);
+		$this->assertEquals('iOS', $reply['hd_specs']['general_platform']);
+		// Note : Default shipped version is 5.0
+		$this->assertEquals('5.1', $reply['hd_specs']['general_platform_version']);
+		$this->assertEquals('Mobile', $reply['hd_specs']['general_type']);
+	}
+
 	/**
 	 * Detection test iPhone 4S Native
 	 * @depends test_cloudConfigExists
@@ -540,10 +616,37 @@ class HD4Test extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('Nokia', $reply['hd_specs']['general_vendor']);
 		$this->assertEquals('Lumia 1020', $reply['hd_specs']['general_model']);
 		$this->assertEquals('Windows Phone', $reply['hd_specs']['general_platform']);
+		$this->assertEquals('8.0', $reply['hd_specs']['general_platform_version']);
 		$this->assertEquals('Mobile', $reply['hd_specs']['general_type']);
 		$this->assertEquals('332', $reply['hd_specs']['display_ppi']);
 	}
 
+	/**
+	 * Detection test Windows Phone Native Nokia Lumia 1020
+	 * @depends test_cloudConfigExists
+	 * @group cloud
+	 **/
+	function test_deviceDetectWindowsPhoneB() {
+		$buildInfo = array (
+			'devicemanufacturer' => 'nokia',
+			'devicename' => 'RM-875',
+			'osname' => 'windows phone',
+			'osversion' => '8.1'
+		);
+		$hd = new HandsetDetection\HD4($this->cloudConfig);
+		$result = $hd->deviceDetect($buildInfo);
+		$reply = $hd->getReply();
+
+		//print_r(json_encode($reply));
+		
+		$this->assertEquals('Nokia', $reply['hd_specs']['general_vendor']);
+		$this->assertEquals('Lumia 1020', $reply['hd_specs']['general_model']);
+		$this->assertEquals('Windows Phone', $reply['hd_specs']['general_platform']);
+		$this->assertEquals('8.1', $reply['hd_specs']['general_platform_version']);
+		$this->assertEquals('Mobile', $reply['hd_specs']['general_type']);
+		$this->assertEquals('332', $reply['hd_specs']['display_ppi']);
+	}
+	
 	// ***************************************************************************************************
 	// ***************************************** Ultimate Tests ******************************************
 	// ***************************************************************************************************
@@ -948,12 +1051,60 @@ class HD4Test extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('Samsung', $reply['hd_specs']['general_vendor']);
 		$this->assertEquals('GT-I9500', $reply['hd_specs']['general_model']);
 		$this->assertEquals('Android', $reply['hd_specs']['general_platform']);
-		//$this->assertEquals('4.4.2', $reply['hd_specs']['general_platform_version']);
+		$this->assertEquals('4.4.2', $reply['hd_specs']['general_platform_version']);
 		$this->assertEquals('Samsung Galaxy S4', $reply['hd_specs']['general_aliases'][0]);
 		$this->assertEquals('Mobile', $reply['hd_specs']['general_type']);
 	}
 
-	//
+	/**
+	 * Detection test Samsung GT-I9500 Native - Note : Device shipped with Android 4.2.2, so this device has been updated.
+	 * @depends test_fetchArchive
+	 * @group ultimate
+	 **/
+	function test_ultimate_deviceDetectBIAndroidUpdatedOs() {
+		$buildInfo = array (
+			'ro.build.id' => 'KOT49H',
+			'ro.build.version.release' => '5.2',
+			'ro.build.version.sdk' => '19',
+			'ro.product.brand' => 'samsung',
+			'ro.product.model' => 'GT-I9500',
+		);
+
+		$hd = new HandsetDetection\HD4($this->ultimateConfig);
+		$result = $hd->deviceDetect($buildInfo);
+		$reply = $hd->getReply();
+
+		$this->assertEquals('Samsung', $reply['hd_specs']['general_vendor']);
+		$this->assertEquals('GT-I9500', $reply['hd_specs']['general_model']);
+		$this->assertEquals('Android', $reply['hd_specs']['general_platform']);
+		$this->assertEquals('5.2', $reply['hd_specs']['general_platform_version']);
+		$this->assertEquals('Samsung Galaxy S4', $reply['hd_specs']['general_aliases'][0]);
+		$this->assertEquals('Mobile', $reply['hd_specs']['general_type']);
+	}
+
+	/**
+	 * Detection test Samsung GT-I9500 Native - Note : Device shipped with Android 4.2.2
+	 * @depends test_fetchArchive
+	 * @group ultimate
+	 **/
+	function test_ultimate_deviceDetectBIAndroidDefaultOs() {
+		$buildInfo = array (
+			'ro.product.brand' => 'samsung',
+			'ro.product.model' => 'GT-I9500',
+		);
+
+		$hd = new HandsetDetection\HD4($this->ultimateConfig);
+		$result = $hd->deviceDetect($buildInfo);
+		$reply = $hd->getReply();
+
+		$this->assertEquals('Samsung', $reply['hd_specs']['general_vendor']);
+		$this->assertEquals('GT-I9500', $reply['hd_specs']['general_model']);
+		$this->assertEquals('Android', $reply['hd_specs']['general_platform']);
+		$this->assertEquals('4.2.2', $reply['hd_specs']['general_platform_version']);
+		$this->assertEquals('Samsung Galaxy S4', $reply['hd_specs']['general_aliases'][0]);
+		$this->assertEquals('Mobile', $reply['hd_specs']['general_type']);
+	}
+	
 	/**
 	 * iPhone 4S Native
 	 * @depends test_fetchArchive
@@ -1019,6 +1170,32 @@ class HD4Test extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('Nokia', $reply['hd_specs']['general_vendor']);
 		$this->assertEquals('Lumia 1020', $reply['hd_specs']['general_model']);
 		$this->assertEquals('Windows Phone', $reply['hd_specs']['general_platform']);
+		$this->assertEquals('8.0', $reply['hd_specs']['general_platform_version']);
+		$this->assertEquals('Mobile', $reply['hd_specs']['general_type']);
+		$this->assertEquals('332', $reply['hd_specs']['display_ppi']);
+	}
+
+	/**
+	 * Windows Phone Native Nokia Lumia 1020
+	 * @depends test_fetchArchive
+	 * @group ultimate
+	 **/
+	function test_ultimate_deviceDetectWindowsPhoneB() {
+		$buildInfo = array (
+			'devicemanufacturer' => 'nokia',
+			'devicename' => 'RM-875',
+			'osname' => 'windows phone',
+			'osversion' => '8.1'
+		);
+
+		$hd = new HandsetDetection\HD4($this->ultimateConfig);
+		$result = $hd->deviceDetect($buildInfo);
+		$reply = $hd->getReply();
+
+		$this->assertEquals('Nokia', $reply['hd_specs']['general_vendor']);
+		$this->assertEquals('Lumia 1020', $reply['hd_specs']['general_model']);
+		$this->assertEquals('Windows Phone', $reply['hd_specs']['general_platform']);
+		$this->assertEquals('8.1', $reply['hd_specs']['general_platform_version']);
 		$this->assertEquals('Mobile', $reply['hd_specs']['general_type']);
 		$this->assertEquals('332', $reply['hd_specs']['display_ppi']);
 	}

--- a/tests/hd4Test.php
+++ b/tests/hd4Test.php
@@ -416,6 +416,27 @@ class HD4Test extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * Android version is not supplied in UA & device base profile has more info than detected platform result
+	 * @depends test_cloudConfigExists
+	 * @group cloud
+	 **/
+	function test_deviceDetectNoPlatformOverlay() {
+		$hd = new HandsetDetection\HD4($this->cloudConfig);
+		$headers = array(
+			'user-agent' => 'Mozilla/5.0 (Linux; U; Android; en-ca; GT-I9500 Build) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1'
+		);
+		$result = $hd->deviceDetect($headers);
+		$reply = $hd->getReply();
+		//print_r($reply);
+		$this->assertTrue($result);
+		$this->assertEquals('Samsung', $reply['hd_specs']['general_vendor']);
+		$this->assertEquals('GT-I9500', $reply['hd_specs']['general_model']);
+		$this->assertEquals('Android', $reply['hd_specs']['general_platform']);
+		$this->assertEquals('4.2.2', $reply['hd_specs']['general_platform_version']);
+		$this->assertEquals('Mobile', $reply['hd_specs']['general_type']);
+	}
+
+	/**
 	 * Detection test Samsung GT-I9500 Native - Note : Device shipped with Android 4.2.2, so this device has been updated.
 	 * @depends test_cloudConfigExists
 	 * @group cloud
@@ -1005,6 +1026,27 @@ class HD4Test extends PHPUnit_Framework_TestCase {
 		$this->assertArrayHasKey('benchmark_max', $reply['hd_specs']);
 	}
 
+	/**
+	 * Android version is not supplied in UA & device base profile has more info than detected platform result
+	 * @depends test_fetchArchive
+	 * @group ultimate
+	 **/
+	function test_ultimate_deviceDetectNoPlatformOverlay() {
+		$hd = new HandsetDetection\HD4($this->ultimateConfig);
+		$headers = array(
+			'user-agent' => 'Mozilla/5.0 (Linux; U; Android; en-ca; GT-I9500 Build) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1'
+		);
+		$result = $hd->deviceDetect($headers);
+		$reply = $hd->getReply();
+		//print_r($reply);
+		$this->assertTrue($result);
+		$this->assertEquals('Samsung', $reply['hd_specs']['general_vendor']);
+		$this->assertEquals('GT-I9500', $reply['hd_specs']['general_model']);
+		$this->assertEquals('Android', $reply['hd_specs']['general_platform']);
+		$this->assertEquals('4.2.2', $reply['hd_specs']['general_platform_version']);
+		$this->assertEquals('Mobile', $reply['hd_specs']['general_type']);
+	}
+	
 	/**
 	 * Samsung GT-I9500 Native - Note : Device shipped with Android 4.2.2, so this device has been updated.
 	 * @depends test_fetchArchive


### PR DESCRIPTION
BugFix : Ticket 13641 - Prevent generic platform detection (empty platform version) from destroying device's specific platform version (default platform that shipped on device) when platform is not supplied in detection data.