### PR TITLE
BugsFixed around using 'none' cache option.

### DIFF
--- a/src/Cache/APC.php
+++ b/src/Cache/APC.php
@@ -32,6 +32,8 @@ use HandsetDetection\Cache\CacheInterface;
 
 class APC implements CacheInterface {
 
+	private $name = 'apc';
+
 	public function __construct($config = array()) {
 		if (! function_exists('apc_store'))
 			throw new \RuntimeException('APC functions not available. Is the APC module installed ?');
@@ -56,5 +58,10 @@ class APC implements CacheInterface {
 	/** Flush Cache */
 	public function flush() {
 		return apc_clear_cache('user');
+	}
+	
+	/** Return cache name **/
+	public function getName() {
+		return $this->name;
 	}
 }

--- a/src/Cache/APCu.php
+++ b/src/Cache/APCu.php
@@ -32,6 +32,8 @@ use HandsetDetection\Cache\CacheInterface;
 
 class APCu implements CacheInterface {
 
+	private $name = 'apcu';
+
 	public function __construct($config = array()) {
 		if (! function_exists('apcu_store'))
 			throw new \RuntimeException('APCu functions not available. Is the APCu module installed ?');
@@ -57,4 +59,9 @@ class APCu implements CacheInterface {
 	public function flush() {
 		return apcu_clear_cache();
 	}
+	
+	/** Return cache name **/
+	public function getName() {
+		return $this->name;
+	}	
 }

--- a/src/Cache/CacheInterface.php
+++ b/src/Cache/CacheInterface.php
@@ -41,4 +41,7 @@ interface CacheInterface {
 
 	/** Flush cache */
 	public function flush();
+
+	/** Get cache name */
+	public function getName();
 }

--- a/src/Cache/File.php
+++ b/src/Cache/File.php
@@ -34,6 +34,7 @@ class File implements CacheInterface {
 
 	/** @var string file system directory */
 	protected $dir;
+	private $name = 'file';
 
 	/**
 	 * Construct a new File cache object.
@@ -99,4 +100,9 @@ class File implements CacheInterface {
 	protected function getFilePath($key) {
 		return $this->dir . $key;
 	}
+	
+	/** Return cache name **/
+	public function getName() {
+		return $this->name;
+	}	
 }

--- a/src/Cache/Memcache.php
+++ b/src/Cache/Memcache.php
@@ -34,6 +34,7 @@ class Memcache implements CacheInterface {
 
 	protected $memcache;
 	protected $options;
+	private $name = 'memcache';
 
 	public function __construct($config=array()) {
 		$this->options = isset($config['cache']['memcache']['options']) ? $config['cache']['memcache']['options'] : 0;
@@ -68,4 +69,9 @@ class Memcache implements CacheInterface {
 	public function flush() {
 		return $this->memcache->flush();
 	}
+	
+	/** Return cache name **/
+	public function getName() {
+		return $this->name;
+	}	
 }

--- a/src/Cache/Memcached.php
+++ b/src/Cache/Memcached.php
@@ -33,7 +33,8 @@ use HandsetDetection\Cache\CacheInterface;
 class Memcached implements CacheInterface {
 
 	protected $memcached;
-
+	private $name = 'memcached';
+	
 	public function __construct($config=array()) {
 		$pool = @$config['cache']['memcached']['pool'];
 		$options = @$config['cache']['memcached']['options'];
@@ -77,5 +78,10 @@ class Memcached implements CacheInterface {
 	/** Flush Cache */
 	public function flush() {
 		return $this->memcached->flush();
+	}
+	
+	/** Return cache name **/
+	public function getName() {
+		return $this->name;
 	}
 }

--- a/src/Cache/None.php
+++ b/src/Cache/None.php
@@ -32,6 +32,8 @@ use HandsetDetection\Cache\CacheInterface;
 
 class None implements CacheInterface {
 
+	private $name = 'none';
+
 	public function __construct($config = array()) {
 	}
 
@@ -53,5 +55,10 @@ class None implements CacheInterface {
 	/** Flush Cache */
 	public function flush() {
 		return false;
+	}
+	
+	/** Return cache name **/
+	public function getName() {
+		return $this->name;
 	}
 }

--- a/src/HDCache.php
+++ b/src/HDCache.php
@@ -132,4 +132,15 @@ class HDCache {
 	function purge() {
 		return $this->cache->flush();
 	}
+
+	/**
+	 * Return the name of the cache provider
+	 *
+	 * @param void
+	 * @return string
+	 **/
+	function getName() {
+		return $this->cache->getName();
+	}
+
 }

--- a/src/HDStore.php
+++ b/src/HDStore.php
@@ -105,7 +105,11 @@ class HDStore implements \Iterator {
 		if (! $this->store($key, $data))
 			return false;
 
-		return $this->Cache->write($key, $data);
+		if ($this->Cache->getName() != 'none') {
+			return $this->Cache->write($key, $data);
+		}
+		
+		return true;
 	}
 
 	/**
@@ -136,8 +140,11 @@ class HDStore implements \Iterator {
 		if (! $reply = $this->fetch($key))
 			return false;
 
-		if (! $this->Cache->write($key, $reply))
-			return false;
+		if ($this->Cache->getName() != 'none') {
+			if (! $this->Cache->write($key, $reply)) {
+				return false;
+			}
+		}
 
 		return $reply;
 	}

--- a/tests/Cache/APCTest.php
+++ b/tests/Cache/APCTest.php
@@ -72,4 +72,15 @@ class APCTest extends PHPUnit_Framework_TestCase {
 		$end = time();
 		$cache->purge();
 	}
+
+	function testGetName() {
+		$config = array(
+			'cache' => array(
+				'apc' => true
+			)
+		);
+
+		$cache = new HandsetDetection\HDCache($config);
+		$this->assertEquals('apc', $cache->getName());
+	}
 }

--- a/tests/Cache/APCuTest.php
+++ b/tests/Cache/APCuTest.php
@@ -72,4 +72,15 @@ class APCuTest extends PHPUnit_Framework_TestCase {
 		$end = time();
 		$cache->purge();
 	}
+
+	function testGetName() {
+		$config = array(
+			'cache' => array(
+				'apcu' => true
+			)
+		);
+
+		$cache = new HandsetDetection\HDCache($config);
+		$this->assertEquals('apcu', $cache->getName());
+	}
 }

--- a/tests/Cache/DefaultTest.php
+++ b/tests/Cache/DefaultTest.php
@@ -17,6 +17,12 @@ class DefaultTest extends PHPUnit_Framework_TestCase {
 		$cache = new HandsetDetection\HDCache();
 		$now = time();
 
+		// Skip tests if no cache installed
+		if ($cache->getName() == 'none') {
+            $this->markTestSkipped('No cache configured/installed');
+			return;
+		}
+		
 		// Test Write & Read
 		$cache->write($now, $this->testData);
 		$reply = $cache->read($now);
@@ -32,6 +38,12 @@ class DefaultTest extends PHPUnit_Framework_TestCase {
 	function testVolume() {
 		$cache = new HandsetDetection\HDCache();
 		$now = time();
+
+		// Skip tests if no cache installed
+		if ($cache->getName() == 'none') {
+            $this->markTestSkipped('No cache configured/installed');
+			return;
+		}
 
 		for($i=0; $i < $this->volumeTest; $i++) {
 			$key = 'test'.$now.$i;
@@ -54,5 +66,11 @@ class DefaultTest extends PHPUnit_Framework_TestCase {
 		}
 		$end = time();
 		$cache->purge();
+	}
+
+	function testGetName() {
+		$cache = new HandsetDetection\HDCache();
+		$cacheNames = array('apc', 'apcu', 'memcache', 'memcached', 'file', 'none');
+		$this->assertContains($cache->getName(), $cacheNames);
 	}
 }

--- a/tests/Cache/FileTest.php
+++ b/tests/Cache/FileTest.php
@@ -77,4 +77,15 @@ class FileTest extends PHPUnit_Framework_TestCase {
 		$end = time();
 		$cache->purge();
 	}
+
+	function testGetName() {
+		$config = array(
+			'cache' => array(
+				'file' => true
+			)
+		);
+
+		$cache = new HandsetDetection\HDCache($config);
+		$this->assertEquals('file', $cache->getName());
+	}
 }

--- a/tests/Cache/MemcacheTest.php
+++ b/tests/Cache/MemcacheTest.php
@@ -78,4 +78,20 @@ class MemcacheTest extends PHPUnit_Framework_TestCase {
 		$end = time();
 		$cache->purge();
 	}
+
+	function testGetName() {
+		$config = array(
+			'cache' => array(
+				'memcache' => array(
+					'options' => 0,
+					'servers' => array(
+						'localhost' => '11211'
+					)
+				)
+			)
+		);
+
+		$cache = new HandsetDetection\HDCache($config);
+		$this->assertEquals('memcache', $cache->getName());
+	}
 }

--- a/tests/Cache/MemcachedTest.php
+++ b/tests/Cache/MemcachedTest.php
@@ -27,8 +27,6 @@ class MemcachedTest extends PHPUnit_Framework_TestCase {
 			)
 		);
 
-
-
 		$cache = new HandsetDetection\HDCache($config);
 		$now = time();
 
@@ -138,4 +136,21 @@ class MemcachedTest extends PHPUnit_Framework_TestCase {
 		$end = time();
 		$cache->purge();
 	}
+	
+	function testGetName() {
+		$config = array(
+			'cache' => array(
+				'memcached' => array(
+					'pool' => 'mypool',
+					'options' => '',
+					'servers' => array(
+						array('localhost', '11211'),
+					)
+				)
+			)
+		);
+
+		$cache = new HandsetDetection\HDCache($config);
+		$this->assertEquals('memcached', $cache->getName());
+	}	
 }

--- a/tests/Cache/NoneTest.php
+++ b/tests/Cache/NoneTest.php
@@ -67,4 +67,15 @@ class NoneTest extends PHPUnit_Framework_TestCase {
 		$end = time();
 		$cache->purge();
 	}
+
+	function testGetName() {
+		$config = array(
+			'cache' => array(
+				'none' => true
+			)
+		);
+
+		$cache = new HandsetDetection\HDCache($config);
+		$this->assertEquals('none', $cache->getName());
+	}
 }

--- a/tests/benchmark.php
+++ b/tests/benchmark.php
@@ -28,9 +28,13 @@ include($configFile);
 if (@$hdconfig['username'] == "your_api_username")
 	die('Please configure your username, secret and site_id');
 
-// Note : After running once comment out deviceFetchArchive so you don't keep downloading the 40Mb specs file.
+// Create a new detection object
 $hd = new HandsetDetection\HD4($configFile);
-$hd->deviceFetchArchive();
+
+// fetch the archive if it does not exist
+if (! file_exists('/tmp/hd40store/user-agent0.json')) {
+	$hd->deviceFetchArchive();
+}
 
 class FileException extends Exception {};
 
@@ -40,7 +44,7 @@ class Benchmark {
 	private $time;
 	private $headers;
 	var $count = 0;
-	private $verbose = false;
+	private $verbose = true;
 
 	function __construct($filename) {
 		try {

--- a/tests/hdStoreTest.php
+++ b/tests/hdStoreTest.php
@@ -23,7 +23,12 @@ class HDStoreTest extends PHPUnit_Framework_TestCase {
 
 		$cache = new HandsetDetection\HDCache();
 		$data = $cache->read($key);
-		$this->assertEquals($this->testData, $data);
+
+		if ($cache->getName() == 'none') {
+			$this->assertFalse($data);
+		} else {
+			$this->assertEquals($this->testData, $data);
+		}
 
 		$exists = is_file($store->directory . DIRECTORY_SEPARATOR . "$key.json");
 		$this->assertTrue($exists);


### PR DESCRIPTION
Improve cache subsystem. Cache providers now report their name. Tests updated.
Store module will only use useful caches (not none cache).
Default Cache provider tests now skipped if no cache option available.
BugFix : Detection now works smoothly without a caching provider (using none cache).
benchmark.php will not download an archive if an existing archive is present in /tmp/hd40cache